### PR TITLE
fix(docker): unblock DigitalOcean App Platform build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 WORKDIR /usr/src/app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY patches ./patches
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS builder


### PR DESCRIPTION
Two issues blocked the kaniko build on DigitalOcean App Platform, fixed in sequence.

## 1. Orphaned `COPY patches`

Commit `23ac7be` removed `patches/libsodium-wrappers-sumo@0.7.16.patch` and the `patchedDependencies` config but left `COPY patches ./patches` in the Dockerfile. With no `patches/` dir in the build context, kaniko hard-fails:

\`\`\`
failed to get fileinfo for /.app_platform_workspace/patches: lstat .../patches: no such file or directory
\`\`\`

→ Removed the orphaned line.

## 2. Husky prepare fails during `pnpm prune --prod`

`pnpm prune --prod` re-runs the `prepare` lifecycle script, but `husky` is a devDependency that prune removes. The bare `husky` command then exits non-zero:

\`\`\`
. prepare: sh: 1: husky: not found
 ELIFECYCLE  Command failed.
\`\`\`

→ Changed `prepare` to `husky || true` so it's a no-op in production builds (standard husky-in-Docker pattern).

Verified: `dev` has no `patches/` dir and no `patchedDependencies`, so nothing depends on either.