### PR TITLE
fix(docker): make husky prepare script non-fatal

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "seed": "tsx ./prisma/seed.ts"
   },
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky || true",
     "preinstall": "node -e \"if (!(process.env.npm_config_user_agent||'').startsWith('pnpm')) { console.error('\\nThis project uses pnpm. Use: pnpm install\\n'); process.exit(1); }\"",
     "lint": "eslint --fix --quiet --config eslint.config.mjs src/",
     "format": "prettier --log-level silent --write src/**/*.ts",


### PR DESCRIPTION
Follow-up to #183 (which fixed the orphaned `COPY patches`). The next kaniko build on DigitalOcean got further but failed at `pnpm prune --prod`.

## Cause

`pnpm prune --prod` re-runs the `prepare` lifecycle script, but `husky` is a devDependency that prune removes. The bare `husky` command then exits non-zero and fails the build:

\`\`\`
. prepare: sh: 1: husky: not found
 ELIFECYCLE  Command failed.
error building image: ... exit status 1
\`\`\`

## Fix

Change `prepare` to `husky || true` so it's a no-op once husky is gone (standard husky-in-Docker pattern). Dev installs still wire up hooks.