### PR TITLE
docs: migrate documentation links to DevHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Masumi Registry Service provides an easy-to-use service to query and filter 
 
 ## Documentation
 
-Refer to the official [Masumi Docs Website](https://docs.masumi.network) for comprehensive documentation.
+Refer to the official [Masumi Docs Website](https://www.masumi.network/dev/masumi) for comprehensive documentation.
 
 Additional guides can be found in the [docs](docs/) folder:
 


### PR DESCRIPTION
## Summary

- replace legacy Masumi and Sokosumi documentation hosts with the canonical DevHub
- preserve route-specific destinations and map moved pages to their current live routes
- keep intentional compatibility references out of this repository change

## Impact

Documentation links now send users and agents to `https://www.masumi.network/dev` instead of retired documentation hosts.

## Validation

- `git diff --check`
- all 42 distinct migrated DevHub URLs returned HTTP 2xx/3xx
- the DevHub documentation audit passed for 304 local routes