### PR TITLE
feat: preserve x402 pricing types in registry

### DIFF
--- a/prisma/migrations/20260720000000_x402_registry_pricing_types/migration.sql
+++ b/prisma/migrations/20260720000000_x402_registry_pricing_types/migration.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "SupportedPaymentSource"
+ADD COLUMN "pricingType" "PricingType";
+
+-- Every x402 source indexed before per-source pricing existed was Fixed by
+-- construction. Preserve that meaning while Cardano rows continue to derive
+-- their pricing from AgentPricing.
+UPDATE "SupportedPaymentSource"
+SET "pricingType" = 'Fixed'
+WHERE "chain" = 'EVM';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,14 +99,15 @@ model RegistryEntry {
 // rows carry paymentSourceType + address; x402/EVM rows carry the scheme/asset/
 // amount/decimals/payTo. Indexed read model — re-synced from chain, never minted.
 model SupportedPaymentSource {
-  id                String   @id @default(cuid())
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  id                String       @id @default(cuid())
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
   chain             String
   network           String
   paymentSourceType String?
   address           String
   scheme            String?
+  pricingType       PricingType?
   asset             String?
   amount            BigInt?
   decimals          Int?

--- a/src/routes/api/registry-entry/schemas.ts
+++ b/src/routes/api/registry-entry/schemas.ts
@@ -165,6 +165,7 @@ const registryEntrySchemaOutput = z
         paymentSourceType: z.string().nullable(),
         address: z.string(),
         scheme: z.string().nullable(),
+        pricingType: z.nativeEnum($Enums.PricingType).nullable(),
         asset: z.string().nullable(),
         amount: z.string().nullable(),
         decimals: z.number().int().nullable(),
@@ -249,6 +250,7 @@ export type RegistryEntrySerializable = {
     paymentSourceType: string | null;
     address: string;
     scheme: string | null;
+    pricingType: $Enums.PricingType | null;
     asset: string | null;
     amount: bigint | number | string | null;
     decimals: number | null;
@@ -316,6 +318,7 @@ export function serializeRegistryEntries(
           paymentSourceType: source.paymentSourceType,
           address: source.address,
           scheme: source.scheme,
+          pricingType: source.pricingType,
           asset: source.asset,
           amount: source.amount != null ? source.amount.toString() : null,
           decimals: source.decimals,

--- a/src/services/cardano-registry/web3-cardano-v2-metadata.spec.ts
+++ b/src/services/cardano-registry/web3-cardano-v2-metadata.spec.ts
@@ -88,6 +88,55 @@ describe('web3CardanoV2 metadata', () => {
     });
   });
 
+  it('preserves dynamic asset allowlists and free x402 pricing', () => {
+    const metadata = web3CardanoV2MetadataSchema.parse({
+      ...sampleV2Metadata,
+      supported_payment_sources: [
+        {
+          chain: 'EVM',
+          network: 'eip155:8453',
+          settlement: {
+            scheme: 'Exact',
+            payTo: '0x1111111111111111111111111111111111111111',
+          },
+          pricing: {
+            pricingType: 'Dynamic',
+            dynamic: [
+              {
+                asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                decimals: '6',
+              },
+            ],
+          },
+        },
+        {
+          chain: 'EVM',
+          network: 'eip155:8453',
+          settlement: {
+            scheme: 'Exact',
+            payTo: '0x2222222222222222222222222222222222222222',
+          },
+          pricing: { pricingType: 'Free' },
+        },
+      ],
+    });
+
+    expect(buildV2SupportedPaymentSourceRows(metadata)).toEqual([
+      expect.objectContaining({
+        pricingType: 'Dynamic',
+        asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        amount: null,
+        decimals: 6,
+      }),
+      expect.objectContaining({
+        pricingType: 'Free',
+        asset: null,
+        amount: null,
+        decimals: null,
+      }),
+    ]);
+  });
+
   it('resolves pricing + paymentType from the Cardano source', () => {
     const metadata = web3CardanoV2MetadataSchema.parse(sampleV2Metadata);
     expect(resolveV2AgentPricingCreate(metadata).pricingType).toBe('Fixed');

--- a/src/services/cardano-registry/web3-cardano-v2-metadata.ts
+++ b/src/services/cardano-registry/web3-cardano-v2-metadata.ts
@@ -5,15 +5,19 @@ import { metadataStringConvert } from '@/utils/metadata-string-convert';
 // On-chain metadata leaves are string | string[] (CIP-25 60-char chunks).
 const metadataString = z.string().or(z.array(z.string()));
 
-const v2AmountSchema = z.object({
+const v2AssetSchema = z.object({
   asset: metadataString,
-  amount: metadataString,
   decimals: metadataString.optional(),
+});
+
+const v2AmountSchema = v2AssetSchema.extend({
+  amount: metadataString,
 });
 
 const v2PricingSchema = z.object({
   pricingType: metadataString,
   fixed: z.array(v2AmountSchema).optional(),
+  dynamic: z.array(v2AssetSchema).optional(),
 });
 
 const v2SettlementSchema = z.object({
@@ -95,6 +99,21 @@ export type Web3CardanoV2Metadata = z.infer<typeof web3CardanoV2MetadataSchema>;
 
 const CARDANO_CHAIN = 'Cardano';
 const EVM_CHAIN = 'EVM';
+const POSTGRES_BIGINT_MAX = 9223372036854775807n;
+
+function parseAtomicAmount(value: string | undefined): bigint | null {
+  if (value == null || !/^\d+$/.test(value)) return null;
+  const amount = BigInt(value);
+  return amount > 0n && amount <= POSTGRES_BIGINT_MAX ? amount : null;
+}
+
+function parseAssetDecimals(value: string | undefined): number | null {
+  if (value == null || !/^\d+$/.test(value)) return null;
+  const decimals = Number(value);
+  return Number.isInteger(decimals) && decimals >= 0 && decimals <= 255
+    ? decimals
+    : null;
+}
 
 function findCardanoPricing(metadata: Web3CardanoV2Metadata) {
   const cardano = (metadata.supported_payment_sources ?? []).find(
@@ -163,19 +182,64 @@ export function buildV2SupportedPaymentSourceRows(
     const settlement = source.settlement ?? {};
 
     if (chain === EVM_CHAIN) {
-      const fixed = source.pricing?.fixed?.[0];
-      const amount = metadataStringConvert(fixed?.amount);
-      const decimals = metadataStringConvert(fixed?.decimals);
+      const pricingType = metadataStringConvert(source.pricing?.pricingType);
       const payTo = metadataStringConvert(settlement.payTo);
+      const scheme = metadataStringConvert(settlement.scheme);
+      if (
+        payTo == null ||
+        scheme == null ||
+        (pricingType !== PricingType.Fixed &&
+          pricingType !== PricingType.Dynamic &&
+          pricingType !== PricingType.Free)
+      ) {
+        continue;
+      }
+
+      let asset: string | null = null;
+      let amount: bigint | null = null;
+      let decimals: number | null = null;
+      if (pricingType === PricingType.Fixed) {
+        const fixed = source.pricing?.fixed?.[0];
+        const fixedAsset = metadataStringConvert(fixed?.asset);
+        const fixedAmount = metadataStringConvert(fixed?.amount);
+        const fixedDecimals = metadataStringConvert(fixed?.decimals);
+        const parsedAmount = parseAtomicAmount(fixedAmount);
+        const parsedDecimals = parseAssetDecimals(fixedDecimals);
+        if (
+          fixedAsset == null ||
+          parsedAmount == null ||
+          parsedDecimals == null
+        ) {
+          continue;
+        }
+        asset = fixedAsset;
+        amount = parsedAmount;
+        decimals = parsedDecimals;
+      } else if (pricingType === PricingType.Dynamic) {
+        const dynamic = source.pricing?.dynamic?.[0];
+        const dynamicAsset = metadataStringConvert(dynamic?.asset);
+        const dynamicDecimals = metadataStringConvert(dynamic?.decimals);
+        if ((dynamicAsset == null) !== (dynamicDecimals == null)) {
+          continue;
+        }
+        asset = dynamicAsset ?? null;
+        decimals =
+          dynamicDecimals != null ? parseAssetDecimals(dynamicDecimals) : null;
+        if (dynamicDecimals != null && decimals == null) {
+          continue;
+        }
+      }
+
       rows.push({
         chain,
         network,
-        address: payTo ?? '',
-        scheme: metadataStringConvert(settlement.scheme) ?? null,
-        asset: metadataStringConvert(fixed?.asset) ?? null,
-        amount: amount != null ? BigInt(amount) : null,
-        decimals: decimals != null ? Number(decimals) : null,
-        payTo: payTo ?? null,
+        address: payTo,
+        scheme,
+        pricingType,
+        asset,
+        amount,
+        decimals,
+        payTo,
         resource: metadataStringConvert(settlement.resource) ?? null,
         ...(settlement.extra !== undefined
           ? { extra: settlement.extra as Prisma.InputJsonValue }

--- a/src/utils/snapshot/export.ts
+++ b/src/utils/snapshot/export.ts
@@ -137,6 +137,7 @@ async function exportSnapshotForSource(sourceId: string): Promise<{
         paymentSourceType: s.paymentSourceType,
         address: s.address,
         scheme: s.scheme,
+        pricingType: s.pricingType,
         asset: s.asset,
         amount: s.amount != null ? s.amount.toString() : null, // BigInt -> string
         decimals: s.decimals,

--- a/src/utils/snapshot/import.ts
+++ b/src/utils/snapshot/import.ts
@@ -282,6 +282,7 @@ async function importSnapshotForSource(
             paymentSourceType: paymentSource.paymentSourceType,
             address: paymentSource.address,
             scheme: paymentSource.scheme,
+            pricingType: paymentSource.pricingType,
             asset: paymentSource.asset,
             amount:
               paymentSource.amount != null

--- a/src/utils/snapshot/schema.ts
+++ b/src/utils/snapshot/schema.ts
@@ -35,22 +35,31 @@ const snapshotExampleOutputSchema = z.object({
   url: z.string(),
 });
 
-const snapshotSupportedPaymentSourceSchema = z.object({
-  chain: z.string(),
-  network: z.string(),
-  paymentSourceType: z.string().nullable(),
-  address: z.string(),
-  scheme: z.string().nullable(),
-  asset: z.string().nullable(),
-  amount: z
-    .string()
-    .regex(/^\d+$/, 'Amount must be a numeric string (BigInt format)')
-    .nullable(),
-  decimals: z.number().int().nullable(),
-  payTo: z.string().nullable(),
-  resource: z.string().nullable(),
-  extra: z.unknown().optional(),
-});
+const snapshotSupportedPaymentSourceSchema = z
+  .object({
+    chain: z.string(),
+    network: z.string(),
+    paymentSourceType: z.string().nullable(),
+    address: z.string(),
+    scheme: z.string().nullable(),
+    // Legacy companion snapshots predate per-source pricing; every EVM row in
+    // that format was Fixed by construction.
+    pricingType: z.nativeEnum(PricingType).nullable().optional(),
+    asset: z.string().nullable(),
+    amount: z
+      .string()
+      .regex(/^\d+$/, 'Amount must be a numeric string (BigInt format)')
+      .nullable(),
+    decimals: z.number().int().nullable(),
+    payTo: z.string().nullable(),
+    resource: z.string().nullable(),
+    extra: z.unknown().optional(),
+  })
+  .transform((source) => ({
+    ...source,
+    pricingType:
+      source.pricingType ?? (source.chain === 'EVM' ? PricingType.Fixed : null),
+  }));
 
 const snapshotEntrySchema = z.object({
   assetIdentifier: z.string().min(1),

--- a/src/utils/snapshot/types.ts
+++ b/src/utils/snapshot/types.ts
@@ -75,6 +75,7 @@ export interface SnapshotSupportedPaymentSource {
   paymentSourceType: string | null;
   address: string;
   scheme: string | null;
+  pricingType: PricingType | null;
   asset: string | null;
   amount: string | null; // BigInt -> string
   decimals: number | null;

--- a/src/utils/swagger-generator/openapi-docs.json
+++ b/src/utils/swagger-generator/openapi-docs.json
@@ -170,8 +170,7 @@
                             "Online",
                             "Offline",
                             "Deregistered",
-                            "Invalid",
-                            "SchemaInvalid"
+                            "Invalid"
                         ]
                     },
                     "id": {
@@ -316,8 +315,7 @@
                             "Online",
                             "Offline",
                             "Deregistered",
-                            "Invalid",
-                            "SchemaInvalid"
+                            "Invalid"
                         ]
                     },
                     "statusUpdatedAt": {
@@ -553,6 +551,16 @@
                                     "type": "string",
                                     "nullable": true
                                 },
+                                "pricingType": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "enum": [
+                                        "Fixed",
+                                        "Free",
+                                        "Dynamic",
+                                        null
+                                    ]
+                                },
                                 "asset": {
                                     "type": "string",
                                     "nullable": true
@@ -580,6 +588,7 @@
                                 "paymentSourceType",
                                 "address",
                                 "scheme",
+                                "pricingType",
                                 "asset",
                                 "amount",
                                 "decimals",
@@ -1209,8 +1218,7 @@
                                                         "Online",
                                                         "Offline",
                                                         "Deregistered",
-                                                        "Invalid",
-                                                        "SchemaInvalid"
+                                                        "Invalid"
                                                     ]
                                                 },
                                                 "maxItems": 5
@@ -1476,8 +1484,7 @@
                                                         "Online",
                                                         "Offline",
                                                         "Deregistered",
-                                                        "Invalid",
-                                                        "SchemaInvalid"
+                                                        "Invalid"
                                                     ]
                                                 },
                                                 "maxItems": 5


### PR DESCRIPTION
## Summary
- persist per-source Fixed, Dynamic, and Free x402 pricing
- parse optional dynamic asset allowlists and reject invalid atomic values
- expose pricingType through the public registry API and OpenAPI schema
- preserve pricing types in snapshots while importing legacy EVM rows as Fixed

## Validation
- pnpm test --runInBand (100 tests)
- pnpm run build
- pnpm run lint

Companion payment-service PR: https://github.com/masumi-network/masumi-payment-service/pull/707