### PR TITLE
feat(registry): store V2 pricing per payment source

### DIFF
--- a/prisma/migrations/20260720010000_source_owned_payment_pricing/migration.sql
+++ b/prisma/migrations/20260720010000_source_owned_payment_pricing/migration.sql
@@ -1,0 +1,263 @@
+-- V1 retains RegistryEntry-owned AgentPricing. V2 stores one complete pricing
+-- relation per SupportedPaymentSource so independently priced Cardano and EVM
+-- options survive indexing without being projected into a shared value.
+
+ALTER TABLE "AgentPricing"
+ADD COLUMN "registryEntryId" TEXT,
+ADD COLUMN "supportedPaymentSourceId" TEXT;
+
+ALTER TABLE "AgentFixedPricing"
+ADD COLUMN "agentPricingId" TEXT;
+
+ALTER TABLE "SupportedPaymentSource"
+ADD COLUMN "sourceIndex" INTEGER,
+ADD COLUMN "dynamicAsset" TEXT,
+ADD COLUMN "dynamicDecimals" INTEGER,
+ADD COLUMN "fixedDecimals" INTEGER;
+
+UPDATE "AgentPricing" AS pricing
+SET "registryEntryId" = entry."id"
+FROM "RegistryEntry" AS entry
+WHERE entry."agentPricingId" = pricing."id";
+
+UPDATE "AgentFixedPricing" AS fixed
+SET "agentPricingId" = pricing."id"
+FROM "AgentPricing" AS pricing
+WHERE pricing."agentFixedPricingId" = fixed."id";
+
+INSERT INTO "AgentPricing" (
+  "id",
+  "createdAt",
+  "updatedAt",
+  "pricingType",
+  "supportedPaymentSourceId"
+)
+SELECT
+  'source-pricing-' || source."id",
+  source."createdAt",
+  source."updatedAt",
+  CASE
+    WHEN source."chain" = 'EVM' THEN COALESCE(source."pricingType", 'Fixed'::"PricingType")
+    ELSE entry_pricing."pricingType"
+  END,
+  source."id"
+FROM "SupportedPaymentSource" AS source
+JOIN "RegistryEntry" AS entry ON entry."id" = source."registryEntryId"
+JOIN "AgentPricing" AS entry_pricing ON entry_pricing."registryEntryId" = entry."id";
+
+INSERT INTO "AgentFixedPricing" (
+  "id",
+  "createdAt",
+  "updatedAt",
+  "agentPricingId"
+)
+SELECT
+  'source-fixed-' || source."id",
+  source."createdAt",
+  source."updatedAt",
+  'source-pricing-' || source."id"
+FROM "SupportedPaymentSource" AS source
+JOIN "AgentPricing" AS source_pricing
+  ON source_pricing."supportedPaymentSourceId" = source."id"
+WHERE source_pricing."pricingType" = 'Fixed';
+
+INSERT INTO "UnitValue" (
+  "id",
+  "createdAt",
+  "updatedAt",
+  "unit",
+  "amount",
+  "agentFixedPricingId"
+)
+SELECT
+  'source-amount-' || source."id",
+  source."createdAt",
+  source."updatedAt",
+  source."asset",
+  source."amount",
+  'source-fixed-' || source."id"
+FROM "SupportedPaymentSource" AS source
+JOIN "AgentPricing" AS source_pricing
+  ON source_pricing."supportedPaymentSourceId" = source."id"
+WHERE source."chain" = 'EVM'
+  AND source_pricing."pricingType" = 'Fixed'
+  AND source."asset" IS NOT NULL
+  AND source."amount" IS NOT NULL;
+
+INSERT INTO "UnitValue" (
+  "id",
+  "createdAt",
+  "updatedAt",
+  "unit",
+  "amount",
+  "agentFixedPricingId"
+)
+SELECT
+  'source-amount-' || source."id" || '-' || amount."id",
+  amount."createdAt",
+  amount."updatedAt",
+  amount."unit",
+  amount."amount",
+  'source-fixed-' || source."id"
+FROM "SupportedPaymentSource" AS source
+JOIN "RegistryEntry" AS entry ON entry."id" = source."registryEntryId"
+JOIN "AgentPricing" AS entry_pricing ON entry_pricing."registryEntryId" = entry."id"
+JOIN "AgentFixedPricing" AS entry_fixed ON entry_fixed."agentPricingId" = entry_pricing."id"
+JOIN "UnitValue" AS amount ON amount."agentFixedPricingId" = entry_fixed."id"
+WHERE source."chain" = 'Cardano'
+  AND entry_pricing."pricingType" = 'Fixed';
+
+WITH ranked_sources AS (
+  SELECT
+    "id",
+    (
+      ROW_NUMBER() OVER (
+      PARTITION BY "registryEntryId"
+      ORDER BY "createdAt", "id"
+      ) - 1
+    )::INTEGER AS "sourceIndex"
+  FROM "SupportedPaymentSource"
+)
+UPDATE "SupportedPaymentSource" AS source
+SET
+  "sourceIndex" = ranked."sourceIndex",
+  "dynamicAsset" = CASE
+    WHEN source."chain" = 'EVM' AND source."pricingType" = 'Dynamic'
+      THEN LOWER(source."asset")
+    ELSE NULL
+  END,
+  "dynamicDecimals" = CASE
+    WHEN source."chain" = 'EVM' AND source."pricingType" = 'Dynamic'
+      THEN source."decimals"
+    ELSE NULL
+  END,
+  "fixedDecimals" = CASE
+    WHEN source."chain" = 'EVM' AND source."pricingType" = 'Fixed'
+      THEN source."decimals"
+    ELSE NULL
+  END
+FROM ranked_sources AS ranked
+WHERE source."id" = ranked."id";
+
+DELETE FROM "UnitValue"
+WHERE "agentFixedPricingId" IN (
+  SELECT "id" FROM "AgentFixedPricing" WHERE "agentPricingId" IS NULL
+);
+DELETE FROM "AgentFixedPricing" WHERE "agentPricingId" IS NULL;
+
+ALTER TABLE "RegistryEntry"
+DROP CONSTRAINT IF EXISTS "RegistryEntry_agentPricingId_fkey";
+ALTER TABLE "AgentPricing"
+DROP CONSTRAINT IF EXISTS "AgentPricing_agentFixedPricingId_fkey";
+ALTER TABLE "UnitValue"
+DROP CONSTRAINT IF EXISTS "UnitValue_agentFixedPricingId_fkey";
+
+DROP INDEX IF EXISTS "AgentPricing_agentFixedPricingId_key";
+
+ALTER TABLE "RegistryEntry" DROP COLUMN "agentPricingId";
+ALTER TABLE "AgentPricing" DROP COLUMN "agentFixedPricingId";
+ALTER TABLE "AgentFixedPricing" ALTER COLUMN "agentPricingId" SET NOT NULL;
+ALTER TABLE "UnitValue" ALTER COLUMN "agentFixedPricingId" SET NOT NULL;
+ALTER TABLE "SupportedPaymentSource" ALTER COLUMN "sourceIndex" SET NOT NULL;
+
+CREATE UNIQUE INDEX "AgentPricing_registryEntryId_key"
+ON "AgentPricing"("registryEntryId");
+CREATE UNIQUE INDEX "AgentPricing_supportedPaymentSourceId_key"
+ON "AgentPricing"("supportedPaymentSourceId");
+CREATE UNIQUE INDEX "AgentFixedPricing_agentPricingId_key"
+ON "AgentFixedPricing"("agentPricingId");
+CREATE UNIQUE INDEX "SupportedPaymentSource_registryEntryId_sourceIndex_key"
+ON "SupportedPaymentSource"("registryEntryId", "sourceIndex");
+
+ALTER TABLE "AgentPricing"
+ADD CONSTRAINT "AgentPricing_registryEntryId_fkey"
+FOREIGN KEY ("registryEntryId") REFERENCES "RegistryEntry"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AgentPricing"
+ADD CONSTRAINT "AgentPricing_supportedPaymentSourceId_fkey"
+FOREIGN KEY ("supportedPaymentSourceId") REFERENCES "SupportedPaymentSource"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AgentFixedPricing"
+ADD CONSTRAINT "AgentFixedPricing_agentPricingId_fkey"
+FOREIGN KEY ("agentPricingId") REFERENCES "AgentPricing"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "UnitValue"
+ADD CONSTRAINT "UnitValue_agentFixedPricingId_fkey"
+FOREIGN KEY ("agentFixedPricingId") REFERENCES "AgentFixedPricing"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+DELETE FROM "AgentPricing"
+WHERE "registryEntryId" IN (
+  SELECT "id" FROM "RegistryEntry" WHERE "metadataVersion" >= 2
+);
+
+DELETE FROM "SupportedPaymentSource"
+WHERE "registryEntryId" IN (
+  SELECT "id" FROM "RegistryEntry" WHERE "metadataVersion" < 2
+);
+
+DELETE FROM "AgentPricing"
+WHERE "registryEntryId" IS NULL
+  AND "supportedPaymentSourceId" IS NULL;
+
+ALTER TABLE "AgentPricing"
+ADD CONSTRAINT "AgentPricing_exactly_one_owner_check" CHECK (
+  num_nonnulls("registryEntryId", "supportedPaymentSourceId") = 1
+);
+
+ALTER TABLE "SupportedPaymentSource"
+DROP COLUMN "pricingType",
+DROP COLUMN "asset",
+DROP COLUMN "amount",
+DROP COLUMN "decimals";
+
+ALTER TABLE "SupportedPaymentSource"
+ADD CONSTRAINT "SupportedPaymentSource_completeness_check" CHECK (
+  (
+    "chain" = 'Cardano'
+    AND "paymentSourceType" IS NOT NULL
+    AND "scheme" IS NULL
+    AND "payTo" IS NULL
+    AND "dynamicAsset" IS NULL
+    AND "dynamicDecimals" IS NULL
+    AND "fixedDecimals" IS NULL
+  )
+  OR (
+    "chain" = 'EVM'
+    AND "paymentSourceType" IS NULL
+    AND "scheme" IS NOT NULL
+    AND "payTo" IS NOT NULL
+    AND (
+      ("dynamicAsset" IS NULL AND "dynamicDecimals" IS NULL)
+      OR ("dynamicAsset" IS NOT NULL AND "dynamicDecimals" IS NOT NULL)
+    )
+  )
+);
+
+UPDATE "RegistryEntry" AS entry
+SET
+  "status" = 'Invalid',
+  "statusUpdatedAt" = CURRENT_TIMESTAMP
+WHERE entry."metadataVersion" >= 2
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "SupportedPaymentSource" AS source
+    WHERE source."registryEntryId" = entry."id"
+  );
+
+-- The old flattened read model did not preserve source array order and stored
+-- only one projected Cardano price. Force a one-time authoritative chain
+-- replay for every source containing V2 entries so sourceIndex and independent
+-- pricing are reconstructed exactly from the on-chain metadata.
+UPDATE "RegistrySource"
+SET
+  "lastTxId" = NULL,
+  "lastCheckedPage" = 1
+WHERE "id" IN (
+  SELECT DISTINCT "registrySourceId"
+  FROM "RegistryEntry"
+  WHERE "metadataVersion" >= 2
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,10 +78,9 @@ model RegistryEntry {
 
   registrySourceId String
 
-  assetIdentifier String       @unique
-  searchText      String       @default("")
-  AgentPricing    AgentPricing @relation(fields: [agentPricingId], references: [id])
-  agentPricingId  String
+  assetIdentifier String        @unique
+  searchText      String        @default("")
+  AgentPricing    AgentPricing?
 
   ExampleOutput ExampleOutput[]
 
@@ -96,28 +95,31 @@ model RegistryEntry {
 
 // Payment sources advertised in a V2 registry entry's metadata
 // (supported_payment_sources). One row per advertised source: Cardano escrow
-// rows carry paymentSourceType + address; x402/EVM rows carry the scheme/asset/
-// amount/decimals/payTo. Indexed read model — re-synced from chain, never minted.
+// rows carry paymentSourceType + address; x402/EVM rows carry settlement and
+// token constraint fields. Complete pricing is source-owned through Pricing.
+// Indexed read model — re-synced from chain, never minted.
 model SupportedPaymentSource {
-  id                String       @id @default(cuid())
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  id                String   @id @default(cuid())
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
   chain             String
   network           String
+  sourceIndex       Int
   paymentSourceType String?
   address           String
   scheme            String?
-  pricingType       PricingType?
-  asset             String?
-  amount            BigInt?
-  decimals          Int?
+  dynamicAsset      String?
+  dynamicDecimals   Int?
+  fixedDecimals     Int?
   payTo             String?
   resource          String?
   extra             Json?
 
   RegistryEntry   RegistryEntry @relation(fields: [registryEntryId], references: [id], onDelete: Cascade)
   registryEntryId String
+  Pricing         AgentPricing?
 
+  @@unique([registryEntryId, sourceIndex])
   @@index([registryEntryId])
 }
 
@@ -196,10 +198,12 @@ model AgentPricing {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  pricingType         PricingType
-  FixedPricing        AgentFixedPricing? @relation(fields: [agentFixedPricingId], references: [id])
-  agentFixedPricingId String?            @unique
-  RegistryEntry       RegistryEntry[]
+  pricingType              PricingType
+  FixedPricing             AgentFixedPricing?
+  RegistryEntry            RegistryEntry?          @relation(fields: [registryEntryId], references: [id], onDelete: Cascade)
+  registryEntryId          String?                 @unique
+  SupportedPaymentSource   SupportedPaymentSource? @relation(fields: [supportedPaymentSourceId], references: [id], onDelete: Cascade)
+  supportedPaymentSourceId String?                 @unique
 }
 
 enum PricingType {
@@ -209,11 +213,12 @@ enum PricingType {
 }
 
 model AgentFixedPricing {
-  id           String        @id @default(cuid())
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  AgentPricing AgentPricing?
-  Amounts      UnitValue[]
+  id             String       @id @default(cuid())
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  AgentPricing   AgentPricing @relation(fields: [agentPricingId], references: [id], onDelete: Cascade)
+  agentPricingId String       @unique
+  Amounts        UnitValue[]
 }
 
 model UnitValue {
@@ -223,8 +228,8 @@ model UnitValue {
 
   amount              BigInt
   unit                String
-  AgentFixedPricing   AgentFixedPricing? @relation(fields: [agentFixedPricingId], references: [id])
-  agentFixedPricingId String?
+  AgentFixedPricing   AgentFixedPricing @relation(fields: [agentFixedPricingId], references: [id], onDelete: Cascade)
+  agentFixedPricingId String
 }
 
 enum PaymentType {

--- a/src/repositories/payment-information/payment-information.repository.ts
+++ b/src/repositories/payment-information/payment-information.repository.ts
@@ -26,6 +26,14 @@ async function getPaymentInformation(currentAgentIdentifier: string) {
       AgentPricing: {
         include: { FixedPricing: { include: { Amounts: true } } },
       },
+      SupportedPaymentSources: {
+        include: {
+          Pricing: {
+            include: { FixedPricing: { include: { Amounts: true } } },
+          },
+        },
+        orderBy: { sourceIndex: 'asc' },
+      },
       Capability: true,
       ExampleOutput: true,
       RegistrySource: {

--- a/src/repositories/registry-entry/registry-entry.repository.ts
+++ b/src/repositories/registry-entry/registry-entry.repository.ts
@@ -54,7 +54,14 @@ async function findRegistryEntries(params: RegistryEntryQueryParams) {
         include: { FixedPricing: { include: { Amounts: true } } },
       },
       ExampleOutput: true,
-      SupportedPaymentSources: true,
+      SupportedPaymentSources: {
+        include: {
+          Pricing: {
+            include: { FixedPricing: { include: { Amounts: true } } },
+          },
+        },
+        orderBy: { sourceIndex: 'asc' },
+      },
       Verifications: true,
     },
     orderBy: [
@@ -94,7 +101,14 @@ async function getRegistryEntryByIdentifier(params: {
         include: { FixedPricing: { include: { Amounts: true } } },
       },
       ExampleOutput: true,
-      SupportedPaymentSources: true,
+      SupportedPaymentSources: {
+        include: {
+          Pricing: {
+            include: { FixedPricing: { include: { Amounts: true } } },
+          },
+        },
+        orderBy: { sourceIndex: 'asc' },
+      },
       Verifications: true,
     },
   });
@@ -166,7 +180,14 @@ async function getRegistryDiffEntries(
         include: { FixedPricing: { include: { Amounts: true } } },
       },
       ExampleOutput: true,
-      SupportedPaymentSources: true,
+      SupportedPaymentSources: {
+        include: {
+          Pricing: {
+            include: { FixedPricing: { include: { Amounts: true } } },
+          },
+        },
+        orderBy: { sourceIndex: 'asc' },
+      },
       Verifications: true,
     },
     orderBy: [

--- a/src/routes/api/payment-information/index.ts
+++ b/src/routes/api/payment-information/index.ts
@@ -45,7 +45,50 @@ export const queryPaymentInformationSchemaOutput = z
         }),
       })
       .or(z.object({ pricingType: z.literal($Enums.PricingType.Free) }))
-      .or(z.object({ pricingType: z.literal($Enums.PricingType.Dynamic) })),
+      .or(z.object({ pricingType: z.literal($Enums.PricingType.Dynamic) }))
+      .nullable(),
+    SupportedPaymentSources: z.array(
+      z.object({
+        chain: z.string(),
+        network: z.string(),
+        sourceIndex: z.number().int().min(0),
+        paymentSourceType: z.string().nullable(),
+        address: z.string(),
+        scheme: z.string().nullable(),
+        pricing: z
+          .object({
+            pricingType: z.literal($Enums.PricingType.Fixed),
+            fixed: z.array(
+              z.object({
+                asset: z.string(),
+                amount: z.string(),
+                decimals: z.number().int().min(0).max(255).optional(),
+              })
+            ),
+          })
+          .or(
+            z.object({
+              pricingType: z.literal($Enums.PricingType.Dynamic),
+              dynamic: z
+                .array(
+                  z.object({
+                    asset: z.string(),
+                    decimals: z.number().int().min(0).max(255),
+                  })
+                )
+                .max(1)
+                .optional(),
+            })
+          )
+          .or(
+            z.object({
+              pricingType: z.literal($Enums.PricingType.Free),
+            })
+          ),
+        payTo: z.string().nullable(),
+        resource: z.string().nullable(),
+      })
+    ),
     name: z.string(),
     description: z.string().nullable(),
     status: z.nativeEnum($Enums.Status),
@@ -136,21 +179,71 @@ export const queryPaymentInformationGet = authenticatedEndpointFactory.build({
         vkey: resolvePaymentKeyHash(sellerWallet.address),
       },
       AgentPricing:
-        result.AgentPricing.pricingType === $Enums.PricingType.Fixed
-          ? {
-              pricingType: $Enums.PricingType.Fixed,
-              FixedPricing: {
-                Amounts:
-                  result.AgentPricing.FixedPricing?.Amounts.map((amount) => ({
-                    amount: amount.amount.toString(),
-                    unit: amount.unit,
-                  })) ?? [],
+        result.AgentPricing == null
+          ? null
+          : result.AgentPricing.pricingType === $Enums.PricingType.Fixed
+            ? {
+                pricingType: $Enums.PricingType.Fixed,
+                FixedPricing: {
+                  Amounts:
+                    result.AgentPricing.FixedPricing?.Amounts.map((amount) => ({
+                      amount: amount.amount.toString(),
+                      unit: amount.unit,
+                    })) ?? [],
+                },
+              }
+            : {
+                // Free or Dynamic — no FixedPricing
+                pricingType: result.AgentPricing.pricingType,
               },
-            }
-          : {
-              // Free or Dynamic — no FixedPricing
-              pricingType: result.AgentPricing.pricingType,
-            },
+      SupportedPaymentSources: result.SupportedPaymentSources.map((source) => {
+        if (source.Pricing == null) {
+          throw createHttpError(
+            500,
+            `Indexed payment source ${source.sourceIndex} is missing pricing`
+          );
+        }
+        const amounts = source.Pricing.FixedPricing?.Amounts ?? [];
+        const pricing =
+          source.Pricing.pricingType === $Enums.PricingType.Fixed
+            ? {
+                pricingType: $Enums.PricingType.Fixed,
+                fixed: amounts.map((amount) => ({
+                  asset: amount.unit,
+                  amount: amount.amount.toString(),
+                  ...(source.fixedDecimals != null
+                    ? { decimals: source.fixedDecimals }
+                    : {}),
+                })),
+              }
+            : source.Pricing.pricingType === $Enums.PricingType.Dynamic
+              ? {
+                  pricingType: $Enums.PricingType.Dynamic,
+                  ...(source.dynamicAsset != null &&
+                  source.dynamicDecimals != null
+                    ? {
+                        dynamic: [
+                          {
+                            asset: source.dynamicAsset,
+                            decimals: source.dynamicDecimals,
+                          },
+                        ],
+                      }
+                    : {}),
+                }
+              : { pricingType: $Enums.PricingType.Free };
+        return {
+          chain: source.chain,
+          network: source.network,
+          sourceIndex: source.sourceIndex,
+          paymentSourceType: source.paymentSourceType,
+          address: source.address,
+          scheme: source.scheme,
+          pricing,
+          payTo: source.payTo,
+          resource: source.resource,
+        };
+      }),
     };
   },
 });

--- a/src/routes/api/registry-entry/schemas.spec.ts
+++ b/src/routes/api/registry-entry/schemas.spec.ts
@@ -1,0 +1,160 @@
+import { Network, PaymentType, PricingType, Status } from '@prisma/client';
+import {
+  serializeRegistryEntries,
+  type RegistryEntrySerializable,
+} from './schemas';
+
+function entry(
+  overrides: Partial<RegistryEntrySerializable> = {}
+): RegistryEntrySerializable {
+  return {
+    id: 'entry-1',
+    name: 'Agent',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    description: null,
+    status: Status.Online,
+    statusUpdatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    lastUptimeCheck: new Date('2026-01-01T00:00:00.000Z'),
+    uptimeCount: 1,
+    uptimeCheckCount: 1,
+    apiBaseUrl: 'https://agent.example',
+    authorName: null,
+    authorOrganization: null,
+    authorContactEmail: null,
+    authorContactOther: null,
+    image: null,
+    privacyPolicy: null,
+    termsAndCondition: null,
+    otherLegal: null,
+    tags: [],
+    assetIdentifier: 'agent-identifier',
+    paymentType: PaymentType.Web3CardanoV2,
+    metadataVersion: 2,
+    RegistrySource: {
+      id: 'source-1',
+      policyId: 'policy',
+      url: null,
+    },
+    Capability: null,
+    AgentPricing: null,
+    ExampleOutput: [],
+    SupportedPaymentSources: [],
+    Verifications: [],
+    ...overrides,
+  };
+}
+
+describe('serializeRegistryEntries', () => {
+  it('keeps V2 pricing under each ordered payment source', () => {
+    const [serialized] = serializeRegistryEntries(
+      [
+        entry({
+          SupportedPaymentSources: [
+            {
+              chain: 'Cardano',
+              network: Network.Preprod,
+              sourceIndex: 1,
+              paymentSourceType: 'Web3CardanoV2',
+              address: 'addr_test1dynamic',
+              scheme: null,
+              dynamicAsset: null,
+              dynamicDecimals: null,
+              fixedDecimals: null,
+              payTo: null,
+              resource: null,
+              Pricing: {
+                pricingType: PricingType.Dynamic,
+                FixedPricing: null,
+              },
+            },
+            {
+              chain: 'Cardano',
+              network: Network.Preprod,
+              sourceIndex: 0,
+              paymentSourceType: 'Web3CardanoV2',
+              address: 'addr_test1fixed',
+              scheme: null,
+              dynamicAsset: null,
+              dynamicDecimals: null,
+              fixedDecimals: null,
+              payTo: null,
+              resource: null,
+              Pricing: {
+                pricingType: PricingType.Fixed,
+                FixedPricing: {
+                  Amounts: [{ unit: '', amount: BigInt(500000) }],
+                },
+              },
+            },
+          ],
+        }),
+      ],
+      10
+    );
+
+    expect(serialized.AgentPricing).toBeNull();
+    expect(serialized.SupportedPaymentSources).toEqual([
+      expect.objectContaining({
+        sourceIndex: 0,
+        pricing: {
+          pricingType: PricingType.Fixed,
+          fixed: [{ asset: '', amount: '500000' }],
+        },
+      }),
+      expect.objectContaining({
+        sourceIndex: 1,
+        pricing: { pricingType: PricingType.Dynamic },
+      }),
+    ]);
+  });
+
+  it('keeps V1 pricing only in AgentPricing', () => {
+    const [serialized] = serializeRegistryEntries(
+      [
+        entry({
+          metadataVersion: 1,
+          paymentType: PaymentType.Web3CardanoV1,
+          AgentPricing: {
+            pricingType: PricingType.Free,
+            FixedPricing: null,
+          },
+        }),
+      ],
+      10
+    );
+
+    expect(serialized.AgentPricing).toEqual({
+      pricingType: PricingType.Free,
+    });
+    expect(serialized.SupportedPaymentSources).toEqual([]);
+  });
+
+  it('fails clearly instead of dropping a persisted source without pricing', () => {
+    expect(() =>
+      serializeRegistryEntries(
+        [
+          entry({
+            SupportedPaymentSources: [
+              {
+                chain: 'Cardano',
+                network: Network.Preprod,
+                sourceIndex: 0,
+                paymentSourceType: 'Web3CardanoV2',
+                address: 'addr_test1missing',
+                scheme: null,
+                dynamicAsset: null,
+                dynamicDecimals: null,
+                fixedDecimals: null,
+                payTo: null,
+                resource: null,
+                Pricing: null,
+              },
+            ],
+          }),
+        ],
+        10
+      )
+    ).toThrow('payment source 0 is missing pricing');
+  });
+});

--- a/src/routes/api/registry-entry/schemas.ts
+++ b/src/routes/api/registry-entry/schemas.ts
@@ -150,7 +150,8 @@ const registryEntrySchemaOutput = z
         z.object({
           pricingType: z.literal($Enums.PricingType.Dynamic),
         })
-      ),
+      )
+      .nullable(),
     ExampleOutput: z.array(
       z.object({
         name: z.string(),
@@ -162,13 +163,40 @@ const registryEntrySchemaOutput = z
       z.object({
         chain: z.string(),
         network: z.string(),
+        sourceIndex: z.number().int().min(0),
         paymentSourceType: z.string().nullable(),
         address: z.string(),
         scheme: z.string().nullable(),
-        pricingType: z.nativeEnum($Enums.PricingType).nullable(),
-        asset: z.string().nullable(),
-        amount: z.string().nullable(),
-        decimals: z.number().int().nullable(),
+        pricing: z
+          .object({
+            pricingType: z.literal($Enums.PricingType.Fixed),
+            fixed: z.array(
+              z.object({
+                asset: z.string(),
+                amount: z.string(),
+                decimals: z.number().int().min(0).max(255).optional(),
+              })
+            ),
+          })
+          .or(
+            z.object({
+              pricingType: z.literal($Enums.PricingType.Dynamic),
+              dynamic: z
+                .array(
+                  z.object({
+                    asset: z.string(),
+                    decimals: z.number().int().min(0).max(255),
+                  })
+                )
+                .max(1)
+                .optional(),
+            })
+          )
+          .or(
+            z.object({
+              pricingType: z.literal($Enums.PricingType.Free),
+            })
+          ),
         payTo: z.string().nullable(),
         resource: z.string().nullable(),
       })
@@ -242,18 +270,24 @@ export type RegistryEntrySerializable = {
     FixedPricing?: {
       Amounts?: { amount: bigint | number | string; unit: string }[] | null;
     } | null;
-  };
+  } | null;
   ExampleOutput: { name: string; mimeType: string; url: string }[];
   SupportedPaymentSources: {
     chain: string;
     network: string;
+    sourceIndex: number;
     paymentSourceType: string | null;
     address: string;
     scheme: string | null;
-    pricingType: $Enums.PricingType | null;
-    asset: string | null;
-    amount: bigint | number | string | null;
-    decimals: number | null;
+    dynamicAsset: string | null;
+    dynamicDecimals: number | null;
+    fixedDecimals: number | null;
+    Pricing: {
+      pricingType: $Enums.PricingType;
+      FixedPricing?: {
+        Amounts?: { amount: bigint | number | string; unit: string }[] | null;
+      } | null;
+    } | null;
     payTo: string | null;
     resource: string | null;
   }[];
@@ -291,41 +325,77 @@ export function serializeRegistryEntries(
             ? new Date(entry.lastUptimeCheck)
             : entry.lastUptimeCheck,
       AgentPricing:
-        entry.AgentPricing.pricingType === $Enums.PricingType.Fixed
-          ? {
-              pricingType: $Enums.PricingType.Fixed,
-              FixedPricing: {
-                Amounts:
-                  entry.AgentPricing.FixedPricing?.Amounts?.map((amount) => ({
-                    amount: amount.amount.toString(),
-                    unit: amount.unit,
-                  })) ?? [],
+        entry.AgentPricing == null
+          ? null
+          : entry.AgentPricing.pricingType === $Enums.PricingType.Fixed
+            ? {
+                pricingType: $Enums.PricingType.Fixed,
+                FixedPricing: {
+                  Amounts:
+                    entry.AgentPricing.FixedPricing?.Amounts?.map((amount) => ({
+                      amount: amount.amount.toString(),
+                      unit: amount.unit,
+                    })) ?? [],
+                },
+              }
+            : {
+                // Free or Dynamic — no FixedPricing
+                pricingType: entry.AgentPricing.pricingType,
               },
-            }
-          : {
-              // Free or Dynamic — no FixedPricing
-              pricingType: entry.AgentPricing.pricingType,
-            },
       ExampleOutput: (entry.ExampleOutput ?? []).map((output) => ({
         name: output.name,
         mimeType: output.mimeType,
         url: output.url,
       })),
-      SupportedPaymentSources: (entry.SupportedPaymentSources ?? []).map(
-        (source) => ({
-          chain: source.chain,
-          network: source.network,
-          paymentSourceType: source.paymentSourceType,
-          address: source.address,
-          scheme: source.scheme,
-          pricingType: source.pricingType,
-          asset: source.asset,
-          amount: source.amount != null ? source.amount.toString() : null,
-          decimals: source.decimals,
-          payTo: source.payTo,
-          resource: source.resource,
-        })
-      ),
+      SupportedPaymentSources: [...(entry.SupportedPaymentSources ?? [])]
+        .sort((left, right) => left.sourceIndex - right.sourceIndex)
+        .map((source) => {
+          if (source.Pricing == null) {
+            throw new Error(
+              `Registry entry ${entry.assetIdentifier} payment source ${source.sourceIndex} is missing pricing`
+            );
+          }
+          const amounts = source.Pricing.FixedPricing?.Amounts ?? [];
+          const pricing =
+            source.Pricing.pricingType === $Enums.PricingType.Fixed
+              ? {
+                  pricingType: $Enums.PricingType.Fixed,
+                  fixed: amounts.map((amount) => ({
+                    asset: amount.unit,
+                    amount: amount.amount.toString(),
+                    ...(source.fixedDecimals != null
+                      ? { decimals: source.fixedDecimals }
+                      : {}),
+                  })),
+                }
+              : source.Pricing.pricingType === $Enums.PricingType.Dynamic
+                ? {
+                    pricingType: $Enums.PricingType.Dynamic,
+                    ...(source.dynamicAsset != null &&
+                    source.dynamicDecimals != null
+                      ? {
+                          dynamic: [
+                            {
+                              asset: source.dynamicAsset,
+                              decimals: source.dynamicDecimals,
+                            },
+                          ],
+                        }
+                      : {}),
+                  }
+                : { pricingType: $Enums.PricingType.Free };
+          return {
+            chain: source.chain,
+            network: source.network,
+            sourceIndex: source.sourceIndex,
+            paymentSourceType: source.paymentSourceType,
+            address: source.address,
+            scheme: source.scheme,
+            pricing,
+            payTo: source.payTo,
+            resource: source.resource,
+          };
+        }),
       Verifications: (entry.Verifications ?? []).map((verification) => ({
         method: verification.method,
         schemaVersion: verification.schemaVersion,

--- a/src/services/cardano-registry/cardano-registry.service.ts
+++ b/src/services/cardano-registry/cardano-registry.service.ts
@@ -21,92 +21,93 @@ import {
 import {
   buildV2SupportedPaymentSourceRows,
   buildV2VerificationRows,
-  resolveV2AgentPricingCreate,
   resolveV2PaymentType,
   web3CardanoV2MetadataSchema,
 } from './web3-cardano-v2-metadata';
 
-const web3CardanoMetadataSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .or(z.array(z.string().min(1))),
-  description: z.string().or(z.array(z.string())).optional(),
-  api_base_url: z
-    .string()
-    .min(1)
-    .or(z.array(z.string().min(1))),
-  example_output: z
-    .array(
-      z.object({
-        name: z
-          .string()
-          .max(60)
-          .or(z.array(z.string().max(60)).min(1).max(1)),
-        mime_type: z
-          .string()
-          .min(1)
-          .max(60)
-          .or(z.array(z.string().min(1).max(60)).min(1).max(1)),
-        url: z.string().or(z.array(z.string())),
-      })
-    )
-    .optional(),
-  capability: z
-    .object({
-      name: z.string().or(z.array(z.string())),
-      version: z
-        .string()
-        .max(60)
-        .or(z.array(z.string().max(60)).min(1).max(1)),
-    })
-    .optional(),
-  author: z.object({
+const web3CardanoMetadataSchema = z
+  .object({
     name: z
       .string()
       .min(1)
       .or(z.array(z.string().min(1))),
-    contact_email: z.string().or(z.array(z.string())).optional(),
-    contact_other: z.string().or(z.array(z.string())).optional(),
-    organization: z.string().or(z.array(z.string())).optional(),
-  }),
-  legal: z
-    .object({
-      privacy_policy: z.string().or(z.array(z.string())).optional(),
-      terms: z.string().or(z.array(z.string())).optional(),
-      other: z.string().or(z.array(z.string())).optional(),
-    })
-    .optional(),
-  tags: z.array(z.string().min(1)).min(1),
-  agentPricing: z
-    .object({
-      pricingType: z.enum([PricingType.Fixed]),
-      fixedPricing: z
-        .array(
-          z.object({
-            amount: z.coerce.number().int().min(1),
-            unit: z
-              .string()
-              .min(1)
-              .or(z.array(z.string().min(1))),
-          })
-        )
+    description: z.string().or(z.array(z.string())).optional(),
+    api_base_url: z
+      .string()
+      .min(1)
+      .or(z.array(z.string().min(1))),
+    example_output: z
+      .array(
+        z.object({
+          name: z
+            .string()
+            .max(60)
+            .or(z.array(z.string().max(60)).min(1).max(1)),
+          mime_type: z
+            .string()
+            .min(1)
+            .max(60)
+            .or(z.array(z.string().min(1).max(60)).min(1).max(1)),
+          url: z.string().or(z.array(z.string())),
+        })
+      )
+      .optional(),
+    capability: z
+      .object({
+        name: z.string().or(z.array(z.string())),
+        version: z
+          .string()
+          .max(60)
+          .or(z.array(z.string().max(60)).min(1).max(1)),
+      })
+      .optional(),
+    author: z.object({
+      name: z
+        .string()
         .min(1)
-        .max(25),
-    })
-    .or(
-      z.object({
-        pricingType: z.enum([PricingType.Free]),
+        .or(z.array(z.string().min(1))),
+      contact_email: z.string().or(z.array(z.string())).optional(),
+      contact_other: z.string().or(z.array(z.string())).optional(),
+      organization: z.string().or(z.array(z.string())).optional(),
+    }),
+    legal: z
+      .object({
+        privacy_policy: z.string().or(z.array(z.string())).optional(),
+        terms: z.string().or(z.array(z.string())).optional(),
+        other: z.string().or(z.array(z.string())).optional(),
       })
-    )
-    .or(
-      z.object({
-        pricingType: z.enum([PricingType.Dynamic]),
+      .optional(),
+    tags: z.array(z.string().min(1)).min(1),
+    agentPricing: z
+      .object({
+        pricingType: z.enum([PricingType.Fixed]),
+        fixedPricing: z
+          .array(
+            z.object({
+              amount: z.coerce.number().int().min(1),
+              unit: z
+                .string()
+                .min(1)
+                .or(z.array(z.string().min(1))),
+            })
+          )
+          .min(1)
+          .max(25),
       })
-    ),
-  image: z.string().or(z.array(z.string())),
-  metadata_version: z.coerce.number().int().min(1).max(1),
-});
+      .or(
+        z.object({
+          pricingType: z.enum([PricingType.Free]),
+        })
+      )
+      .or(
+        z.object({
+          pricingType: z.enum([PricingType.Dynamic]),
+        })
+      ),
+    image: z.string().or(z.array(z.string())),
+    metadata_version: z.coerce.number().int().min(1).max(1),
+  })
+  .strict();
 
 type SyncableRegistrySource = {
   id: string;
@@ -120,6 +121,23 @@ type SyncableRegistrySource = {
 };
 
 const healthMutex = new Mutex();
+
+async function markRegistryMetadataInvalid(params: {
+  sourceId: string;
+  assetIdentifier: string;
+}): Promise<void> {
+  await prisma.registryEntry.updateMany({
+    where: {
+      registrySourceId: params.sourceId,
+      assetIdentifier: params.assetIdentifier,
+    },
+    data: {
+      status: $Enums.Status.Invalid,
+      statusUpdatedAt: new Date(),
+    },
+  });
+}
+
 export async function updateHealthCheck(onlyEntriesAfter?: Date | undefined) {
   logger.info('Updating cardano registry entries health check: ', {
     onlyEntriesAfter: onlyEntriesAfter,
@@ -182,7 +200,16 @@ export async function updateHealthCheck(onlyEntriesAfter?: Date | undefined) {
               },
             },
             ExampleOutput: true,
-            SupportedPaymentSources: true,
+            SupportedPaymentSources: {
+              include: {
+                Pricing: {
+                  include: {
+                    FixedPricing: { include: { Amounts: true } },
+                  },
+                },
+              },
+              orderBy: { sourceIndex: 'asc' },
+            },
             Verifications: true,
           },
         });
@@ -215,7 +242,16 @@ export async function updateHealthCheck(onlyEntriesAfter?: Date | undefined) {
               },
             },
             ExampleOutput: true,
-            SupportedPaymentSources: true,
+            SupportedPaymentSources: {
+              include: {
+                Pricing: {
+                  include: {
+                    FixedPricing: { include: { Amounts: true } },
+                  },
+                },
+              },
+              orderBy: { sourceIndex: 'asc' },
+            },
             Verifications: true,
           },
         });
@@ -361,6 +397,14 @@ async function syncWeb3CardanoRegistryEntry(params: {
   );
 
   if (!parsedMetadata.success) {
+    logger.warn('Rejected invalid V1 registry metadata', {
+      assetIdentifier: params.asset,
+      validationIssues: parsedMetadata.error.issues,
+    });
+    await markRegistryMetadataInvalid({
+      sourceId: params.source.id,
+      assetIdentifier: params.asset,
+    });
     return false;
   }
 
@@ -506,6 +550,14 @@ async function syncWeb3CardanoV2RegistryEntry(params: {
     params.onchainMetadata
   );
   if (!parsedMetadata.success) {
+    logger.warn('Rejected invalid V2 registry metadata', {
+      assetIdentifier: params.asset,
+      validationIssues: parsedMetadata.error.issues,
+    });
+    await markRegistryMetadataInvalid({
+      sourceId: params.source.id,
+      assetIdentifier: params.asset,
+    });
     return false;
   }
   const metadata = parsedMetadata.data;
@@ -582,12 +634,11 @@ async function syncWeb3CardanoV2RegistryEntry(params: {
       lastUptimeCheck: new Date(),
       uptimeCount: { increment: status == $Enums.Status.Online ? 1 : 0 },
       uptimeCheckCount: { increment: 1 },
-      AgentPricing: { create: resolveV2AgentPricingCreate(metadata) },
       ExampleOutput: { deleteMany: {}, ...(exampleOutputCreate ?? {}) },
       SupportedPaymentSources: {
         deleteMany: {},
         ...(supportedPaymentSourceRows.length > 0
-          ? { createMany: { data: supportedPaymentSourceRows } }
+          ? { create: supportedPaymentSourceRows }
           : {}),
       },
       Verifications: {
@@ -602,11 +653,10 @@ async function syncWeb3CardanoV2RegistryEntry(params: {
       lastUptimeCheck: new Date(),
       uptimeCount: status == $Enums.Status.Online ? 1 : 0,
       uptimeCheckCount: 1,
-      AgentPricing: { create: resolveV2AgentPricingCreate(metadata) },
       ExampleOutput: exampleOutputCreate,
       SupportedPaymentSources:
         supportedPaymentSourceRows.length > 0
-          ? { createMany: { data: supportedPaymentSourceRows } }
+          ? { create: supportedPaymentSourceRows }
           : undefined,
       Verifications:
         verificationRows.length > 0

--- a/src/services/cardano-registry/web3-cardano-v2-metadata.spec.ts
+++ b/src/services/cardano-registry/web3-cardano-v2-metadata.spec.ts
@@ -1,7 +1,6 @@
 import {
   buildV2SupportedPaymentSourceRows,
   buildV2VerificationRows,
-  resolveV2AgentPricingCreate,
   resolveV2PaymentType,
   web3CardanoV2MetadataSchema,
 } from './web3-cardano-v2-metadata';
@@ -29,10 +28,19 @@ const sampleV2Metadata = {
     {
       chain: 'EVM',
       network: 'eip155:8453',
-      settlement: { scheme: 'Exact', payTo: '0xRecipient' },
+      settlement: {
+        scheme: 'Exact',
+        payTo: '0x1111111111111111111111111111111111111111',
+      },
       pricing: {
         pricingType: 'Fixed',
-        fixed: [{ asset: '0xUSDC', amount: '1000000', decimals: '6' }],
+        fixed: [
+          {
+            asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            amount: '1000000',
+            decimals: '6',
+          },
+        ],
       },
     },
   ],
@@ -59,17 +67,19 @@ describe('web3CardanoV2 metadata', () => {
     expect(rows).toHaveLength(2);
     expect(rows.find((row) => row.chain === 'Cardano')).toMatchObject({
       network: 'Preprod',
+      sourceIndex: 0,
       paymentSourceType: 'Web3CardanoV2',
       address: 'addr_test1example',
+      Pricing: { create: expect.objectContaining({ pricingType: 'Fixed' }) },
     });
     expect(rows.find((row) => row.chain === 'EVM')).toMatchObject({
       network: 'eip155:8453',
+      sourceIndex: 1,
       scheme: 'Exact',
-      asset: '0xUSDC',
-      amount: 1000000n,
-      decimals: 6,
-      payTo: '0xRecipient',
-      address: '0xRecipient',
+      fixedDecimals: 6,
+      payTo: '0x1111111111111111111111111111111111111111',
+      address: '0x1111111111111111111111111111111111111111',
+      Pricing: { create: expect.objectContaining({ pricingType: 'Fixed' }) },
     });
   });
 
@@ -123,24 +133,99 @@ describe('web3CardanoV2 metadata', () => {
 
     expect(buildV2SupportedPaymentSourceRows(metadata)).toEqual([
       expect.objectContaining({
-        pricingType: 'Dynamic',
-        asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-        amount: null,
-        decimals: 6,
+        dynamicAsset: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        dynamicDecimals: 6,
+        Pricing: {
+          create: expect.objectContaining({ pricingType: 'Dynamic' }),
+        },
       }),
       expect.objectContaining({
-        pricingType: 'Free',
-        asset: null,
-        amount: null,
-        decimals: null,
+        dynamicAsset: null,
+        dynamicDecimals: null,
+        fixedDecimals: null,
+        Pricing: { create: expect.objectContaining({ pricingType: 'Free' }) },
       }),
     ]);
   });
 
-  it('resolves pricing + paymentType from the Cardano source', () => {
+  it('resolves paymentType from all Cardano sources', () => {
     const metadata = web3CardanoV2MetadataSchema.parse(sampleV2Metadata);
-    expect(resolveV2AgentPricingCreate(metadata).pricingType).toBe('Fixed');
     expect(resolveV2PaymentType(metadata)).toBe('Web3CardanoV2');
+  });
+
+  it('preserves independently priced Cardano sources', () => {
+    const metadata = web3CardanoV2MetadataSchema.parse({
+      ...sampleV2Metadata,
+      supported_payment_sources: [
+        sampleV2Metadata.supported_payment_sources[0],
+        {
+          ...sampleV2Metadata.supported_payment_sources[0],
+          pricing: { pricingType: 'Dynamic' },
+        },
+      ],
+    });
+
+    const rows = buildV2SupportedPaymentSourceRows(metadata);
+    expect(rows.map((row) => row.Pricing)).toEqual([
+      { create: expect.objectContaining({ pricingType: 'Fixed' }) },
+      { create: { pricingType: 'Dynamic' } },
+    ]);
+  });
+
+  it('rejects duplicate source options with a row-level error', () => {
+    const metadata = web3CardanoV2MetadataSchema.parse({
+      ...sampleV2Metadata,
+      supported_payment_sources: [
+        sampleV2Metadata.supported_payment_sources[0],
+        sampleV2Metadata.supported_payment_sources[0],
+      ],
+    });
+
+    expect(() => buildV2SupportedPaymentSourceRows(metadata)).toThrow(
+      'supported_payment_sources[1] duplicates an earlier supported payment source'
+    );
+  });
+
+  it('rejects legacy top-level agentPricing on V2', () => {
+    const result = web3CardanoV2MetadataSchema.safeParse({
+      ...sampleV2Metadata,
+      agentPricing: { pricingType: 'Free' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('Unrecognized key');
+    }
+  });
+
+  it('caps payment sources and Cardano fixed-price baskets', () => {
+    expect(
+      web3CardanoV2MetadataSchema.safeParse({
+        ...sampleV2Metadata,
+        supported_payment_sources: Array.from(
+          { length: 26 },
+          () => sampleV2Metadata.supported_payment_sources[0]
+        ),
+      }).success
+    ).toBe(false);
+
+    const metadata = web3CardanoV2MetadataSchema.parse({
+      ...sampleV2Metadata,
+      supported_payment_sources: [
+        {
+          ...sampleV2Metadata.supported_payment_sources[0],
+          pricing: {
+            pricingType: 'Fixed',
+            fixed: Array.from({ length: 6 }, (_, index) => ({
+              asset: index === 0 ? '' : `asset-${index}`,
+              amount: '1',
+            })),
+          },
+        },
+      ],
+    });
+    expect(() => buildV2SupportedPaymentSourceRows(metadata)).toThrow(
+      'must not contain more than 5 assets'
+    );
   });
 
   it('drops a verification missing a required anchor', () => {

--- a/src/services/cardano-registry/web3-cardano-v2-metadata.ts
+++ b/src/services/cardano-registry/web3-cardano-v2-metadata.ts
@@ -2,6 +2,9 @@ import { $Enums, PricingType, Prisma } from '@prisma/client';
 import { z } from '@/utils/zod-openapi';
 import { metadataStringConvert } from '@/utils/metadata-string-convert';
 
+const MAX_SUPPORTED_PAYMENT_SOURCES = 25;
+const MAX_FIXED_PRICES = 5;
+
 // On-chain metadata leaves are string | string[] (CIP-25 60-char chunks).
 const metadataString = z.string().or(z.array(z.string()));
 
@@ -14,27 +17,33 @@ const v2AmountSchema = v2AssetSchema.extend({
   amount: metadataString,
 });
 
-const v2PricingSchema = z.object({
-  pricingType: metadataString,
-  fixed: z.array(v2AmountSchema).optional(),
-  dynamic: z.array(v2AssetSchema).optional(),
-});
+const v2PricingSchema = z
+  .object({
+    pricingType: metadataString,
+    fixed: z.array(v2AmountSchema).optional(),
+    dynamic: z.array(v2AssetSchema).optional(),
+  })
+  .strict();
 
-const v2SettlementSchema = z.object({
-  paymentSourceType: metadataString.optional(),
-  address: metadataString.optional(),
-  scheme: metadataString.optional(),
-  payTo: metadataString.optional(),
-  resource: metadataString.optional(),
-  extra: z.unknown().optional(),
-});
+const v2SettlementSchema = z
+  .object({
+    paymentSourceType: metadataString.optional(),
+    address: metadataString.optional(),
+    scheme: metadataString.optional(),
+    payTo: metadataString.optional(),
+    resource: metadataString.optional(),
+    extra: z.unknown().optional(),
+  })
+  .strict();
 
-const v2SupportedPaymentSourceSchema = z.object({
-  chain: metadataString,
-  network: metadataString,
-  settlement: v2SettlementSchema.optional(),
-  pricing: v2PricingSchema.optional(),
-});
+const v2SupportedPaymentSourceSchema = z
+  .object({
+    chain: metadataString,
+    network: metadataString,
+    settlement: v2SettlementSchema.optional(),
+    pricing: v2PricingSchema.optional(),
+  })
+  .strict();
 
 const v2VerificationRefSchema = z.object({
   aid: metadataString.optional(),
@@ -59,47 +68,53 @@ const v2VerificationSchema = z.object({
  * (pricing is resolved from the Cardano source). Mirrors what
  * masumi-payment-service mints for Web3CardanoV2 entries.
  */
-export const web3CardanoV2MetadataSchema = z.object({
-  name: metadataString,
-  description: metadataString.optional(),
-  api_base_url: metadataString,
-  example_output: z
-    .array(
-      z.object({
-        name: metadataString,
-        mime_type: metadataString,
-        url: metadataString,
-      })
-    )
-    .optional(),
-  capability: z
-    .object({ name: metadataString, version: metadataString })
-    .optional(),
-  author: z.object({
+export const web3CardanoV2MetadataSchema = z
+  .object({
     name: metadataString,
-    contact_email: metadataString.optional(),
-    contact_other: metadataString.optional(),
-    organization: metadataString.optional(),
-  }),
-  legal: z
-    .object({
-      privacy_policy: metadataString.optional(),
-      terms: metadataString.optional(),
-      other: metadataString.optional(),
-    })
-    .optional(),
-  tags: z.array(z.string().min(1)).min(1),
-  image: metadataString,
-  metadata_version: z.coerce.number().int().min(2).max(2),
-  supported_payment_sources: z.array(v2SupportedPaymentSourceSchema).optional(),
-  verifications: z.array(v2VerificationSchema).optional(),
-});
+    description: metadataString.optional(),
+    api_base_url: metadataString,
+    example_output: z
+      .array(
+        z.object({
+          name: metadataString,
+          mime_type: metadataString,
+          url: metadataString,
+        })
+      )
+      .optional(),
+    capability: z
+      .object({ name: metadataString, version: metadataString })
+      .optional(),
+    author: z.object({
+      name: metadataString,
+      contact_email: metadataString.optional(),
+      contact_other: metadataString.optional(),
+      organization: metadataString.optional(),
+    }),
+    legal: z
+      .object({
+        privacy_policy: metadataString.optional(),
+        terms: metadataString.optional(),
+        other: metadataString.optional(),
+      })
+      .optional(),
+    tags: z.array(z.string().min(1)).min(1),
+    image: metadataString,
+    metadata_version: z.coerce.number().int().min(2).max(2),
+    supported_payment_sources: z
+      .array(v2SupportedPaymentSourceSchema)
+      .min(1)
+      .max(MAX_SUPPORTED_PAYMENT_SOURCES),
+    verifications: z.array(v2VerificationSchema).optional(),
+  })
+  .strict();
 
 export type Web3CardanoV2Metadata = z.infer<typeof web3CardanoV2MetadataSchema>;
 
 const CARDANO_CHAIN = 'Cardano';
 const EVM_CHAIN = 'EVM';
 const POSTGRES_BIGINT_MAX = 9223372036854775807n;
+const EVM_ADDRESS = /^0x[a-fA-F0-9]{40}$/;
 
 function parseAtomicAmount(value: string | undefined): bigint | null {
   if (value == null || !/^\d+$/.test(value)) return null;
@@ -115,132 +130,251 @@ function parseAssetDecimals(value: string | undefined): number | null {
     : null;
 }
 
-function findCardanoPricing(metadata: Web3CardanoV2Metadata) {
-  const cardano = (metadata.supported_payment_sources ?? []).find(
-    (source) => metadataStringConvert(source.chain) === CARDANO_CHAIN
+export function resolveV2PaymentType(
+  metadata: Web3CardanoV2Metadata
+): $Enums.PaymentType {
+  const hasPaidCardanoSource = (metadata.supported_payment_sources ?? []).some(
+    (source) => {
+      if (metadataStringConvert(source.chain) !== CARDANO_CHAIN) return false;
+      const pricingType = metadataStringConvert(source.pricing?.pricingType);
+      return (
+        pricingType === PricingType.Fixed || pricingType === PricingType.Dynamic
+      );
+    }
   );
-  return cardano?.pricing;
+  return hasPaidCardanoSource
+    ? $Enums.PaymentType.Web3CardanoV2
+    : $Enums.PaymentType.None;
 }
 
-// V2 has no top-level agentPricing; resolve it from the Cardano source pricing.
-export function resolveV2AgentPricingCreate(
-  metadata: Web3CardanoV2Metadata
-): Prisma.AgentPricingCreateWithoutRegistryEntryInput {
-  const pricing = findCardanoPricing(metadata);
-  const pricingType = pricing
-    ? metadataStringConvert(pricing.pricingType)
-    : undefined;
+function buildPricingCreate(
+  source: NonNullable<
+    Web3CardanoV2Metadata['supported_payment_sources']
+  >[number],
+  sourceIndex: number,
+  chain: string
+): {
+  pricing: Prisma.AgentPricingCreateWithoutSupportedPaymentSourceInput;
+  dynamicAsset: string | null;
+  dynamicDecimals: number | null;
+  fixedDecimals: number | null;
+  canonicalPricing: string;
+} {
+  const pricingType = metadataStringConvert(source.pricing?.pricingType);
+  const optionLabel = `supported_payment_sources[${sourceIndex}]`;
+  if (
+    pricingType !== PricingType.Fixed &&
+    pricingType !== PricingType.Dynamic &&
+    pricingType !== PricingType.Free
+  ) {
+    throw new Error(`${optionLabel}.pricing.pricingType is missing or invalid`);
+  }
 
-  if (pricingType === PricingType.Fixed && pricing?.fixed?.length) {
+  if (pricingType === PricingType.Free) {
+    if (source.pricing?.fixed != null || source.pricing?.dynamic != null) {
+      throw new Error(
+        `${optionLabel}.pricing must not set fixed or dynamic values when pricingType is Free`
+      );
+    }
     return {
-      pricingType: PricingType.Fixed,
+      pricing: { pricingType },
+      dynamicAsset: null,
+      dynamicDecimals: null,
+      fixedDecimals: null,
+      canonicalPricing: JSON.stringify({ pricingType }),
+    };
+  }
+
+  if (pricingType === PricingType.Dynamic) {
+    if (source.pricing?.fixed != null) {
+      throw new Error(
+        `${optionLabel}.pricing.fixed is only valid when pricingType is Fixed`
+      );
+    }
+    if (chain === CARDANO_CHAIN && source.pricing?.dynamic != null) {
+      throw new Error(
+        `${optionLabel}.pricing.dynamic is not supported for Cardano`
+      );
+    }
+    const dynamic = source.pricing?.dynamic?.[0];
+    if (
+      source.pricing?.dynamic != null &&
+      source.pricing.dynamic.length !== 1
+    ) {
+      throw new Error(
+        `${optionLabel}.pricing.dynamic must contain exactly one accepted asset`
+      );
+    }
+    const asset = metadataStringConvert(dynamic?.asset);
+    const decimalsRaw = metadataStringConvert(dynamic?.decimals);
+    const decimals = parseAssetDecimals(decimalsRaw);
+    if (
+      chain === EVM_CHAIN &&
+      dynamic != null &&
+      (asset == null ||
+        !EVM_ADDRESS.test(asset) ||
+        decimalsRaw == null ||
+        decimals == null)
+    ) {
+      throw new Error(
+        `${optionLabel}.pricing.dynamic[0] must contain an ERC-20 contract and valid decimals`
+      );
+    }
+    return {
+      pricing: { pricingType },
+      dynamicAsset: asset?.toLowerCase() ?? null,
+      dynamicDecimals: decimals,
+      fixedDecimals: null,
+      canonicalPricing: JSON.stringify({
+        pricingType,
+        dynamic:
+          asset != null && decimals != null
+            ? [{ asset: asset.toLowerCase(), decimals }]
+            : [],
+      }),
+    };
+  }
+
+  if (source.pricing?.dynamic != null) {
+    throw new Error(
+      `${optionLabel}.pricing.dynamic is only valid when pricingType is Dynamic`
+    );
+  }
+  const fixed = source.pricing?.fixed;
+  if (fixed == null || fixed.length === 0) {
+    throw new Error(
+      `${optionLabel}.pricing.fixed requires at least one asset and amount`
+    );
+  }
+  if (fixed.length > MAX_FIXED_PRICES) {
+    throw new Error(
+      `${optionLabel}.pricing.fixed must not contain more than ${MAX_FIXED_PRICES} assets`
+    );
+  }
+  if (chain === EVM_CHAIN && fixed.length !== 1) {
+    throw new Error(
+      `${optionLabel}.pricing.fixed requires exactly one ERC-20 asset for x402`
+    );
+  }
+
+  const amounts = fixed.map((entry, priceIndex) => {
+    const asset = metadataStringConvert(entry.asset);
+    const amount = parseAtomicAmount(metadataStringConvert(entry.amount));
+    const decimalsRaw = metadataStringConvert(entry.decimals);
+    const decimals = parseAssetDecimals(decimalsRaw);
+    if (asset == null || amount == null) {
+      throw new Error(
+        `${optionLabel}.pricing.fixed[${priceIndex}] requires a valid asset and positive atomic amount`
+      );
+    }
+    if (chain === CARDANO_CHAIN && decimalsRaw != null) {
+      throw new Error(
+        `${optionLabel}.pricing.fixed[${priceIndex}].decimals is not valid for Cardano`
+      );
+    }
+    if (
+      chain === EVM_CHAIN &&
+      (!EVM_ADDRESS.test(asset) || decimalsRaw == null || decimals == null)
+    ) {
+      throw new Error(
+        `${optionLabel}.pricing.fixed[${priceIndex}] requires an ERC-20 contract and valid decimals`
+      );
+    }
+    return {
+      unit: chain === EVM_CHAIN ? asset.toLowerCase() : asset,
+      amount,
+      decimals,
+    };
+  });
+
+  return {
+    pricing: {
+      pricingType,
       FixedPricing: {
         create: {
           Amounts: {
             createMany: {
-              data: pricing.fixed.map((entry) => ({
-                amount: BigInt(metadataStringConvert(entry.amount) ?? '0'),
-                unit: metadataStringConvert(entry.asset) ?? '',
-              })),
+              data: amounts.map(({ unit, amount }) => ({ unit, amount })),
             },
           },
         },
       },
-    };
-  }
-  if (pricingType === PricingType.Dynamic) {
-    return { pricingType: PricingType.Dynamic };
-  }
-  // Free, or no resolvable pricing.
-  return { pricingType: PricingType.Free };
+    },
+    dynamicAsset: null,
+    dynamicDecimals: null,
+    fixedDecimals: chain === EVM_CHAIN ? (amounts[0]?.decimals ?? null) : null,
+    canonicalPricing: JSON.stringify({
+      pricingType,
+      fixed: amounts
+        .map(({ unit, amount, decimals }) => ({
+          asset: unit.toLowerCase(),
+          amount: amount.toString(),
+          decimals,
+        }))
+        .sort((left, right) =>
+          `${left.asset}:${left.amount}:${left.decimals ?? ''}`.localeCompare(
+            `${right.asset}:${right.amount}:${right.decimals ?? ''}`
+          )
+        ),
+    }),
+  };
 }
 
-export function resolveV2PaymentType(
-  metadata: Web3CardanoV2Metadata
-): $Enums.PaymentType {
-  const pricing = findCardanoPricing(metadata);
-  const pricingType = pricing
-    ? metadataStringConvert(pricing.pricingType)
-    : undefined;
-  // No Cardano source (e.g. an x402/EVM-only entry) means no Cardano escrow, so
-  // the Cardano payment type is None — same as Free. Keeps paymentType consistent
-  // with resolveV2AgentPricingCreate, which resolves to Free in both cases.
-  return pricingType == null || pricingType === PricingType.Free
-    ? $Enums.PaymentType.None
-    : $Enums.PaymentType.Web3CardanoV2;
-}
-
-// Flatten the grouped on-chain sources into SupportedPaymentSource rows.
+// Flatten the grouped on-chain sources into source-owned relational creates.
 export function buildV2SupportedPaymentSourceRows(
   metadata: Web3CardanoV2Metadata
-): Prisma.SupportedPaymentSourceCreateManyRegistryEntryInput[] {
-  const rows: Prisma.SupportedPaymentSourceCreateManyRegistryEntryInput[] = [];
-  for (const source of metadata.supported_payment_sources ?? []) {
+): Prisma.SupportedPaymentSourceCreateWithoutRegistryEntryInput[] {
+  const rows: Prisma.SupportedPaymentSourceCreateWithoutRegistryEntryInput[] =
+    [];
+  const seenSources = new Set<string>();
+  for (const [sourceIndex, source] of (
+    metadata.supported_payment_sources ?? []
+  ).entries()) {
     const chain = metadataStringConvert(source.chain);
     const network = metadataStringConvert(source.network);
-    if (chain == null || network == null) continue;
+    const optionLabel = `supported_payment_sources[${sourceIndex}]`;
+    if ((chain !== CARDANO_CHAIN && chain !== EVM_CHAIN) || network == null) {
+      throw new Error(`${optionLabel} has an unsupported chain or network`);
+    }
     const settlement = source.settlement ?? {};
+    const pricing = buildPricingCreate(source, sourceIndex, chain);
 
     if (chain === EVM_CHAIN) {
-      const pricingType = metadataStringConvert(source.pricing?.pricingType);
       const payTo = metadataStringConvert(settlement.payTo);
       const scheme = metadataStringConvert(settlement.scheme);
-      if (
-        payTo == null ||
-        scheme == null ||
-        (pricingType !== PricingType.Fixed &&
-          pricingType !== PricingType.Dynamic &&
-          pricingType !== PricingType.Free)
-      ) {
-        continue;
+      if (payTo == null || !EVM_ADDRESS.test(payTo) || scheme !== 'Exact') {
+        throw new Error(
+          `${optionLabel}.settlement requires scheme Exact and a valid payTo address`
+        );
       }
-
-      let asset: string | null = null;
-      let amount: bigint | null = null;
-      let decimals: number | null = null;
-      if (pricingType === PricingType.Fixed) {
-        const fixed = source.pricing?.fixed?.[0];
-        const fixedAsset = metadataStringConvert(fixed?.asset);
-        const fixedAmount = metadataStringConvert(fixed?.amount);
-        const fixedDecimals = metadataStringConvert(fixed?.decimals);
-        const parsedAmount = parseAtomicAmount(fixedAmount);
-        const parsedDecimals = parseAssetDecimals(fixedDecimals);
-        if (
-          fixedAsset == null ||
-          parsedAmount == null ||
-          parsedDecimals == null
-        ) {
-          continue;
-        }
-        asset = fixedAsset;
-        amount = parsedAmount;
-        decimals = parsedDecimals;
-      } else if (pricingType === PricingType.Dynamic) {
-        const dynamic = source.pricing?.dynamic?.[0];
-        const dynamicAsset = metadataStringConvert(dynamic?.asset);
-        const dynamicDecimals = metadataStringConvert(dynamic?.decimals);
-        if ((dynamicAsset == null) !== (dynamicDecimals == null)) {
-          continue;
-        }
-        asset = dynamicAsset ?? null;
-        decimals =
-          dynamicDecimals != null ? parseAssetDecimals(dynamicDecimals) : null;
-        if (dynamicDecimals != null && decimals == null) {
-          continue;
-        }
+      const resource = metadataStringConvert(settlement.resource) ?? null;
+      const canonicalSource = JSON.stringify({
+        chain,
+        network,
+        scheme,
+        payTo: payTo.toLowerCase(),
+        resource: resource ?? '',
+        pricing: pricing.canonicalPricing,
+      });
+      if (seenSources.has(canonicalSource)) {
+        throw new Error(
+          `${optionLabel} duplicates an earlier supported payment source`
+        );
       }
+      seenSources.add(canonicalSource);
 
       rows.push({
         chain,
         network,
-        address: payTo,
+        sourceIndex,
+        address: payTo.toLowerCase(),
         scheme,
-        pricingType,
-        asset,
-        amount,
-        decimals,
-        payTo,
-        resource: metadataStringConvert(settlement.resource) ?? null,
+        payTo: payTo.toLowerCase(),
+        dynamicAsset: pricing.dynamicAsset,
+        dynamicDecimals: pricing.dynamicDecimals,
+        fixedDecimals: pricing.fixedDecimals,
+        Pricing: { create: pricing.pricing },
+        resource,
         ...(settlement.extra !== undefined
           ? { extra: settlement.extra as Prisma.InputJsonValue }
           : {}),
@@ -249,14 +383,40 @@ export function buildV2SupportedPaymentSourceRows(
     }
 
     const address = metadataStringConvert(settlement.address);
-    if (address == null) continue;
+    const paymentSourceType = metadataStringConvert(
+      settlement.paymentSourceType
+    );
+    if (address == null || paymentSourceType !== 'Web3CardanoV2') {
+      throw new Error(
+        `${optionLabel}.settlement requires a Web3CardanoV2 paymentSourceType and address`
+      );
+    }
+    const canonicalSource = JSON.stringify({
+      chain,
+      network,
+      paymentSourceType,
+      address,
+      pricing: pricing.canonicalPricing,
+    });
+    if (seenSources.has(canonicalSource)) {
+      throw new Error(
+        `${optionLabel} duplicates an earlier supported payment source`
+      );
+    }
+    seenSources.add(canonicalSource);
     rows.push({
       chain,
       network,
+      sourceIndex,
       address,
-      paymentSourceType:
-        metadataStringConvert(settlement.paymentSourceType) ?? null,
+      paymentSourceType,
+      Pricing: { create: pricing.pricing },
     });
+  }
+  if (rows.length === 0) {
+    throw new Error(
+      'V2 metadata requires at least one supported_payment_sources entry with source-local pricing'
+    );
   }
   return rows;
 }

--- a/src/services/health-check/health-check.service.ts
+++ b/src/services/health-check/health-check.service.ts
@@ -305,9 +305,16 @@ async function checkVerifyAndUpdateRegistryEntries({
       FixedPricing: {
         Amounts: { amount: bigint; unit: string }[];
       } | null;
-    };
+    } | null;
     ExampleOutput: { name: string; mimeType: string; url: string }[];
-    SupportedPaymentSources: SupportedPaymentSource[];
+    SupportedPaymentSources: (SupportedPaymentSource & {
+      Pricing: {
+        pricingType: PricingType;
+        FixedPricing: {
+          Amounts: { amount: bigint; unit: string }[];
+        } | null;
+      } | null;
+    })[];
     Verifications: AgentVerification[];
   })[];
   minHealthCheckDate: Date | undefined;
@@ -428,7 +435,16 @@ async function checkVerifyAndUpdateRegistryEntries({
             Capability: true,
             RegistrySource: true,
             ExampleOutput: true,
-            SupportedPaymentSources: true,
+            SupportedPaymentSources: {
+              include: {
+                Pricing: {
+                  include: {
+                    FixedPricing: { include: { Amounts: true } },
+                  },
+                },
+              },
+              orderBy: { sourceIndex: 'asc' },
+            },
             Verifications: true,
           },
           data: {

--- a/src/utils/snapshot/export.ts
+++ b/src/utils/snapshot/export.ts
@@ -10,6 +10,7 @@ import type {
   SnapshotEntryPaymentSources,
   ExportResult,
 } from './types';
+import { SNAPSHOT_VERSION } from './types';
 
 function bigIntReplacer(_key: string, value: unknown): unknown {
   if (typeof value === 'bigint') {
@@ -30,24 +31,30 @@ function mapEntryToSnapshot(
       FixedPricing: {
         Amounts: { amount: bigint; unit: string }[];
       } | null;
-    };
+    } | null;
     ExampleOutput: { name: string; mimeType: string; url: string }[];
   }
 ): SnapshotEntry {
   // Build pricing object
-  const agentPricing: SnapshotAgentPricing =
-    entry.AgentPricing.pricingType === 'Free'
-      ? { pricingType: 'Free', fixedPricing: null }
-      : {
-          pricingType: 'Fixed',
-          fixedPricing: {
-            amounts:
-              entry.AgentPricing.FixedPricing?.Amounts.map((a) => ({
-                amount: a.amount.toString(), // BigInt -> string
-                unit: a.unit,
-              })) ?? [],
-          },
-        };
+  const agentPricing: SnapshotAgentPricing | null =
+    entry.AgentPricing == null
+      ? null
+      : entry.AgentPricing.pricingType === 'Free' ||
+          entry.AgentPricing.pricingType === 'Dynamic'
+        ? {
+            pricingType: entry.AgentPricing.pricingType,
+            fixedPricing: null,
+          }
+        : {
+            pricingType: 'Fixed',
+            fixedPricing: {
+              amounts:
+                entry.AgentPricing.FixedPricing?.Amounts.map((a) => ({
+                  amount: a.amount.toString(), // BigInt -> string
+                  unit: a.unit,
+                })) ?? [],
+            },
+          };
 
   return {
     assetIdentifier: entry.assetIdentifier,
@@ -106,7 +113,16 @@ async function exportSnapshotForSource(sourceId: string): Promise<{
         },
       },
       ExampleOutput: true,
-      SupportedPaymentSources: true,
+      SupportedPaymentSources: {
+        include: {
+          Pricing: {
+            include: {
+              FixedPricing: { include: { Amounts: true } },
+            },
+          },
+        },
+        orderBy: { sourceIndex: 'asc' },
+      },
     },
     orderBy: { assetIdentifier: 'asc' },
   });
@@ -115,7 +131,7 @@ async function exportSnapshotForSource(sourceId: string): Promise<{
   const exportedAt = new Date().toISOString();
 
   const snapshot: Snapshot = {
-    version: '1.0.0',
+    version: SNAPSHOT_VERSION,
     exportedAt,
     network: source.network,
     policyId: source.policyId,
@@ -131,26 +147,59 @@ async function exportSnapshotForSource(sourceId: string): Promise<{
     .filter((entry) => entry.SupportedPaymentSources.length > 0)
     .map((entry) => ({
       assetIdentifier: entry.assetIdentifier,
-      sources: entry.SupportedPaymentSources.map((s) => ({
-        chain: s.chain,
-        network: s.network,
-        paymentSourceType: s.paymentSourceType,
-        address: s.address,
-        scheme: s.scheme,
-        pricingType: s.pricingType,
-        asset: s.asset,
-        amount: s.amount != null ? s.amount.toString() : null, // BigInt -> string
-        decimals: s.decimals,
-        payTo: s.payTo,
-        resource: s.resource,
-        ...(s.extra != null ? { extra: s.extra } : {}),
-      })),
+      sources: entry.SupportedPaymentSources.map((s) => {
+        if (s.Pricing == null) {
+          throw new Error(
+            `Registry entry ${entry.assetIdentifier} payment source ${s.sourceIndex} is missing pricing`
+          );
+        }
+        const amounts = s.Pricing.FixedPricing?.Amounts ?? [];
+        const pricing =
+          s.Pricing.pricingType === 'Fixed'
+            ? {
+                pricingType: 'Fixed' as const,
+                fixed: amounts.map((amount) => ({
+                  asset: amount.unit,
+                  amount: amount.amount.toString(),
+                  ...(s.fixedDecimals != null
+                    ? { decimals: s.fixedDecimals }
+                    : {}),
+                })),
+              }
+            : s.Pricing.pricingType === 'Dynamic'
+              ? {
+                  pricingType: 'Dynamic' as const,
+                  ...(s.dynamicAsset != null && s.dynamicDecimals != null
+                    ? {
+                        dynamic: [
+                          {
+                            asset: s.dynamicAsset,
+                            decimals: s.dynamicDecimals,
+                          },
+                        ],
+                      }
+                    : {}),
+                }
+              : { pricingType: 'Free' as const };
+        return {
+          chain: s.chain,
+          network: s.network,
+          sourceIndex: s.sourceIndex,
+          paymentSourceType: s.paymentSourceType,
+          address: s.address,
+          scheme: s.scheme,
+          pricing,
+          payTo: s.payTo,
+          resource: s.resource,
+          ...(s.extra != null ? { extra: s.extra } : {}),
+        };
+      }),
     }));
 
   const paymentSources: PaymentSourcesSnapshot | null =
     paymentSourceEntries.length > 0
       ? {
-          version: '1.0.0',
+          version: SNAPSHOT_VERSION,
           exportedAt,
           network: source.network,
           policyId: source.policyId,

--- a/src/utils/snapshot/import.spec.ts
+++ b/src/utils/snapshot/import.spec.ts
@@ -1,0 +1,167 @@
+import { Network, PaymentType, PricingType, Status } from '@prisma/client';
+import {
+  SNAPSHOT_VERSION,
+  type PaymentSourcesSnapshot,
+  type Snapshot,
+} from './types';
+import { validateSnapshotPricingLayout } from './pricing-layout';
+
+function snapshotEntry(metadataVersion: number) {
+  return {
+    assetIdentifier: `agent-${metadataVersion}`,
+    name: 'Agent',
+    apiBaseUrl: 'https://agent.example',
+    description: null,
+    image: '',
+    tags: [],
+    authorName: null,
+    authorContactEmail: null,
+    authorContactOther: null,
+    authorOrganization: null,
+    privacyPolicy: null,
+    termsAndCondition: null,
+    otherLegal: null,
+    lastUptimeCheck: '2026-01-01T00:00:00.000Z',
+    uptimeCount: 0,
+    uptimeCheckCount: 0,
+    status: Status.Online,
+    statusUpdatedAt: '2026-01-01T00:00:00.000Z',
+    paymentType:
+      metadataVersion >= 2
+        ? PaymentType.Web3CardanoV2
+        : PaymentType.Web3CardanoV1,
+    metadataVersion,
+    capability: null,
+    agentPricing:
+      metadataVersion >= 2
+        ? null
+        : {
+            pricingType: PricingType.Free,
+            fixedPricing: null,
+          },
+    exampleOutputs: [],
+  };
+}
+
+function snapshot(entries: Snapshot['entries']): Snapshot {
+  return {
+    version: SNAPSHOT_VERSION,
+    exportedAt: '2026-01-01T00:00:00.000Z',
+    network: Network.Preprod,
+    policyId: 'policy',
+    lastTxId: null,
+    lastCheckedPage: 1,
+    entryCount: entries.length,
+    entries,
+  };
+}
+
+function paymentSources(
+  entries: PaymentSourcesSnapshot['entries']
+): PaymentSourcesSnapshot {
+  return {
+    version: SNAPSHOT_VERSION,
+    exportedAt: '2026-01-01T00:00:00.000Z',
+    network: Network.Preprod,
+    policyId: 'policy',
+    entryCount: entries.length,
+    sourceCount: entries.reduce(
+      (count, entry) => count + entry.sources.length,
+      0
+    ),
+    entries,
+  };
+}
+
+describe('validateSnapshotPricingLayout', () => {
+  it('accepts V1 top-level pricing and V2 source-owned pricing', () => {
+    const v1 = snapshotEntry(1);
+    const v2 = snapshotEntry(2);
+
+    expect(() =>
+      validateSnapshotPricingLayout(
+        snapshot([v1, v2]),
+        paymentSources([
+          {
+            assetIdentifier: v2.assetIdentifier,
+            sources: [
+              {
+                chain: 'EVM',
+                network: 'eip155:8453',
+                sourceIndex: 0,
+                paymentSourceType: null,
+                address: '0x1111111111111111111111111111111111111111',
+                scheme: 'Exact',
+                pricing: { pricingType: 'Dynamic' },
+                payTo: '0x1111111111111111111111111111111111111111',
+                resource: null,
+              },
+            ],
+          },
+        ])
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects top-level pricing on V2', () => {
+    const v2 = {
+      ...snapshotEntry(2),
+      agentPricing: {
+        pricingType: PricingType.Free,
+        fixedPricing: null,
+      },
+    };
+
+    expect(() =>
+      validateSnapshotPricingLayout(
+        snapshot([v2]),
+        paymentSources([
+          {
+            assetIdentifier: v2.assetIdentifier,
+            sources: [
+              {
+                chain: 'Cardano',
+                network: Network.Preprod,
+                sourceIndex: 0,
+                paymentSourceType: 'Web3CardanoV2',
+                address: 'addr_test1example',
+                scheme: null,
+                pricing: { pricingType: 'Free' },
+                payTo: null,
+                resource: null,
+              },
+            ],
+          },
+        ])
+      )
+    ).toThrow('must not set top-level agentPricing');
+  });
+
+  it('rejects supported payment sources on V1', () => {
+    const v1 = snapshotEntry(1);
+
+    expect(() =>
+      validateSnapshotPricingLayout(
+        snapshot([v1]),
+        paymentSources([
+          {
+            assetIdentifier: v1.assetIdentifier,
+            sources: [
+              {
+                chain: 'Cardano',
+                network: Network.Preprod,
+                sourceIndex: 0,
+                paymentSourceType: 'Web3CardanoV2',
+                address: 'addr_test1example',
+                scheme: null,
+                pricing: { pricingType: 'Free' },
+                payTo: null,
+                resource: null,
+              },
+            ],
+          },
+        ])
+      )
+    ).toThrow('must not set supported payment sources');
+  });
+});

--- a/src/utils/snapshot/import.ts
+++ b/src/utils/snapshot/import.ts
@@ -5,7 +5,13 @@ import { createId } from '@paralleldrive/cuid2';
 import { prisma } from '@/utils/db';
 import { logger } from '@/utils/logger';
 import { validateSnapshot, validatePaymentSources } from './schema';
-import type { Snapshot, PaymentSourcesSnapshot, ImportResult } from './types';
+import {
+  SNAPSHOT_VERSION,
+  type Snapshot,
+  type PaymentSourcesSnapshot,
+  type ImportResult,
+} from './types';
+import { validateSnapshotPricingLayout } from './pricing-layout';
 
 const MAX_SNAPSHOT_BYTES = 100 * 1024 * 1024; // 100 MB
 
@@ -99,7 +105,7 @@ async function importSnapshotForSource(
     );
   }
 
-  if (snapshot.version !== '1.0.0') {
+  if (snapshot.version !== SNAPSHOT_VERSION) {
     throw new Error(`Unsupported snapshot version: ${snapshot.version}`);
   }
 
@@ -108,6 +114,8 @@ async function importSnapshotForSource(
       `Entry count mismatch: array has ${snapshot.entries.length}, metadata says ${snapshot.entryCount}`
     );
   }
+
+  validateSnapshotPricingLayout(snapshot, paymentSources ?? null);
 
   if (options.dryRun) {
     const existingCount = await prisma.registryEntry.count({
@@ -188,7 +196,7 @@ async function importSnapshotForSource(
       }
 
       // 2. Build the flat row sets, wiring FKs via client-generated ids.
-      const fixedPricingRows: { id: string }[] = [];
+      const fixedPricingRows: Prisma.AgentFixedPricingCreateManyInput[] = [];
       const amountRows: {
         agentFixedPricingId: string;
         amount: bigint;
@@ -197,32 +205,43 @@ async function importSnapshotForSource(
       const agentPricingRows: Prisma.AgentPricingCreateManyInput[] = [];
       const entryRows: Prisma.RegistryEntryCreateManyInput[] = [];
       const exampleOutputRows: Prisma.ExampleOutputCreateManyInput[] = [];
+      const supportedPaymentSourceRows: Prisma.SupportedPaymentSourceCreateManyInput[] =
+        [];
 
       // assetIdentifier -> generated entry id, used to attach the companion
       // payment-sources file back to its entries.
       const entryIdByAsset = new Map<string, string>();
 
-      for (const entry of snapshot.entries) {
+      const addPricingRows = (params: {
+        pricingType: 'Fixed' | 'Free' | 'Dynamic';
+        amounts?: { amount: string; unit: string }[];
+        registryEntryId?: string;
+        supportedPaymentSourceId?: string;
+      }) => {
         const agentPricingId = createId();
-        if (entry.agentPricing.pricingType === 'Free') {
-          agentPricingRows.push({ id: agentPricingId, pricingType: 'Free' });
-        } else {
-          const agentFixedPricingId = createId();
-          fixedPricingRows.push({ id: agentFixedPricingId });
-          for (const a of entry.agentPricing.fixedPricing!.amounts) {
-            amountRows.push({
-              agentFixedPricingId,
-              amount: BigInt(a.amount),
-              unit: a.unit,
-            });
-          }
-          agentPricingRows.push({
-            id: agentPricingId,
-            pricingType: 'Fixed',
+        agentPricingRows.push({
+          id: agentPricingId,
+          pricingType: params.pricingType,
+          registryEntryId: params.registryEntryId,
+          supportedPaymentSourceId: params.supportedPaymentSourceId,
+        });
+        if (params.pricingType !== 'Fixed') return;
+
+        const agentFixedPricingId = createId();
+        fixedPricingRows.push({
+          id: agentFixedPricingId,
+          agentPricingId,
+        });
+        for (const amount of params.amounts ?? []) {
+          amountRows.push({
             agentFixedPricingId,
+            amount: BigInt(amount.amount),
+            unit: amount.unit,
           });
         }
+      };
 
+      for (const entry of snapshot.entries) {
         const entryId = createId();
         entryIdByAsset.set(entry.assetIdentifier, entryId);
         entryRows.push({
@@ -253,8 +272,14 @@ async function importSnapshotForSource(
                 capabilityKey(entry.capability.name, entry.capability.version)
               )
             : null,
-          agentPricingId,
         });
+        if (entry.agentPricing != null) {
+          addPricingRows({
+            pricingType: entry.agentPricing.pricingType,
+            amounts: entry.agentPricing.fixedPricing?.amounts,
+            registryEntryId: entryId,
+          });
+        }
 
         for (const output of entry.exampleOutputs) {
           exampleOutputRows.push({ registryEntryId: entryId, ...output });
@@ -262,60 +287,56 @@ async function importSnapshotForSource(
       }
 
       // Optional companion file: V2 payment sources, matched back to entries by
-      // assetIdentifier. Unknown identifiers (file drift) are skipped, not fatal.
-      const supportedPaymentSourceRows: Prisma.SupportedPaymentSourceCreateManyInput[] =
-        [];
-      let unmatchedPaymentSources = 0;
+      // assetIdentifier. Unknown identifiers indicate incompatible or corrupted
+      // snapshot files and must fail instead of silently dropping payment rails.
       for (const paymentEntry of paymentSources?.entries ?? []) {
         const registryEntryId = entryIdByAsset.get(
           paymentEntry.assetIdentifier
         );
         if (registryEntryId == null) {
-          unmatchedPaymentSources += paymentEntry.sources.length;
-          continue;
+          throw new Error(
+            `Payment-sources entry ${paymentEntry.assetIdentifier} has no matching registry entry`
+          );
         }
         for (const paymentSource of paymentEntry.sources) {
+          const supportedPaymentSourceId = createId();
+          const fixedPrice =
+            paymentSource.pricing.pricingType === 'Fixed'
+              ? paymentSource.pricing.fixed
+              : undefined;
+          const dynamicAsset =
+            paymentSource.pricing.pricingType === 'Dynamic'
+              ? paymentSource.pricing.dynamic?.[0]
+              : undefined;
           supportedPaymentSourceRows.push({
+            id: supportedPaymentSourceId,
             registryEntryId,
             chain: paymentSource.chain,
             network: paymentSource.network,
+            sourceIndex: paymentSource.sourceIndex,
             paymentSourceType: paymentSource.paymentSourceType,
             address: paymentSource.address,
             scheme: paymentSource.scheme,
-            pricingType: paymentSource.pricingType,
-            asset: paymentSource.asset,
-            amount:
-              paymentSource.amount != null
-                ? BigInt(paymentSource.amount)
-                : null,
-            decimals: paymentSource.decimals,
+            dynamicAsset: dynamicAsset?.asset ?? null,
+            dynamicDecimals: dynamicAsset?.decimals ?? null,
+            fixedDecimals: fixedPrice?.[0]?.decimals ?? null,
             payTo: paymentSource.payTo,
             resource: paymentSource.resource,
             ...(paymentSource.extra != null
               ? { extra: paymentSource.extra as Prisma.InputJsonValue }
               : {}),
           });
+          addPricingRows({
+            pricingType: paymentSource.pricing.pricingType,
+            amounts: fixedPrice?.map((price) => ({
+              amount: price.amount,
+              unit: price.asset,
+            })),
+            supportedPaymentSourceId,
+          });
         }
       }
-      if (unmatchedPaymentSources > 0) {
-        logger.warn(
-          `Skipped ${unmatchedPaymentSources} payment source(s) with no matching entry in ${source.network} ${source.policyId}`
-        );
-      }
-
       // 3. Insert in FK-dependency order.
-      await createManyChunked(
-        (data) => tx.agentFixedPricing.createMany({ data }),
-        fixedPricingRows
-      );
-      await createManyChunked(
-        (data) => tx.unitValue.createMany({ data }),
-        amountRows
-      );
-      await createManyChunked(
-        (data) => tx.agentPricing.createMany({ data }),
-        agentPricingRows
-      );
       await createManyChunked(
         (data) => tx.registryEntry.createMany({ data }),
         entryRows
@@ -327,6 +348,18 @@ async function importSnapshotForSource(
       await createManyChunked(
         (data) => tx.supportedPaymentSource.createMany({ data }),
         supportedPaymentSourceRows
+      );
+      await createManyChunked(
+        (data) => tx.agentPricing.createMany({ data }),
+        agentPricingRows
+      );
+      await createManyChunked(
+        (data) => tx.agentFixedPricing.createMany({ data }),
+        fixedPricingRows
+      );
+      await createManyChunked(
+        (data) => tx.unitValue.createMany({ data }),
+        amountRows
       );
       if (supportedPaymentSourceRows.length > 0) {
         logger.info(

--- a/src/utils/snapshot/pricing-layout.ts
+++ b/src/utils/snapshot/pricing-layout.ts
@@ -1,0 +1,74 @@
+import type { PaymentSourcesSnapshot, Snapshot } from './types';
+
+export function validateSnapshotPricingLayout(
+  snapshot: Snapshot,
+  paymentSources: PaymentSourcesSnapshot | null
+): void {
+  const sourceEntryByAsset = new Map(
+    (paymentSources?.entries ?? []).map((entry) => [
+      entry.assetIdentifier,
+      entry,
+    ])
+  );
+  if (sourceEntryByAsset.size !== (paymentSources?.entries.length ?? 0)) {
+    throw new Error(
+      'Payment-sources file contains duplicate registry entry identifiers'
+    );
+  }
+
+  for (const paymentEntry of paymentSources?.entries ?? []) {
+    if (paymentEntry.sources.length === 0) {
+      throw new Error(
+        `Payment-sources entry ${paymentEntry.assetIdentifier} must contain at least one source`
+      );
+    }
+    const indexes = new Set(
+      paymentEntry.sources.map((source) => source.sourceIndex)
+    );
+    if (indexes.size !== paymentEntry.sources.length) {
+      throw new Error(
+        `Payment-sources entry ${paymentEntry.assetIdentifier} contains duplicate sourceIndex values`
+      );
+    }
+  }
+
+  for (const entry of snapshot.entries) {
+    const sourceEntry = sourceEntryByAsset.get(entry.assetIdentifier);
+    if (entry.metadataVersion >= 2) {
+      if (entry.agentPricing != null) {
+        throw new Error(
+          `V2 snapshot entry ${entry.assetIdentifier} must not set top-level agentPricing`
+        );
+      }
+      if (sourceEntry == null) {
+        throw new Error(
+          `V2 snapshot entry ${entry.assetIdentifier} requires source-owned pricing in the payment-sources file`
+        );
+      }
+      continue;
+    }
+
+    if (entry.agentPricing == null) {
+      throw new Error(
+        `V1 snapshot entry ${entry.assetIdentifier} requires top-level agentPricing`
+      );
+    }
+    if (sourceEntry != null) {
+      throw new Error(
+        `V1 snapshot entry ${entry.assetIdentifier} must not set supported payment sources`
+      );
+    }
+  }
+
+  for (const assetIdentifier of sourceEntryByAsset.keys()) {
+    if (
+      !snapshot.entries.some(
+        (entry) => entry.assetIdentifier === assetIdentifier
+      )
+    ) {
+      throw new Error(
+        `Payment-sources entry ${assetIdentifier} has no matching registry entry`
+      );
+    }
+  }
+}

--- a/src/utils/snapshot/schema.ts
+++ b/src/utils/snapshot/schema.ts
@@ -1,5 +1,6 @@
 import { z } from '@/utils/zod-openapi';
 import { Network, PaymentType, PricingType, Status } from '@prisma/client';
+import { SNAPSHOT_VERSION } from './types';
 
 const snapshotAmountSchema = z.object({
   amount: z
@@ -21,6 +22,10 @@ const snapshotAgentPricingSchema = z.discriminatedUnion('pricingType', [
     pricingType: z.literal(PricingType.Fixed),
     fixedPricing: snapshotFixedPricingSchema,
   }),
+  z.object({
+    pricingType: z.literal(PricingType.Dynamic),
+    fixedPricing: z.null(),
+  }),
 ]);
 
 const snapshotCapabilitySchema = z.object({
@@ -35,31 +40,46 @@ const snapshotExampleOutputSchema = z.object({
   url: z.string(),
 });
 
-const snapshotSupportedPaymentSourceSchema = z
-  .object({
-    chain: z.string(),
-    network: z.string(),
-    paymentSourceType: z.string().nullable(),
-    address: z.string(),
-    scheme: z.string().nullable(),
-    // Legacy companion snapshots predate per-source pricing; every EVM row in
-    // that format was Fixed by construction.
-    pricingType: z.nativeEnum(PricingType).nullable().optional(),
-    asset: z.string().nullable(),
-    amount: z
-      .string()
-      .regex(/^\d+$/, 'Amount must be a numeric string (BigInt format)')
-      .nullable(),
-    decimals: z.number().int().nullable(),
-    payTo: z.string().nullable(),
-    resource: z.string().nullable(),
-    extra: z.unknown().optional(),
-  })
-  .transform((source) => ({
-    ...source,
-    pricingType:
-      source.pricingType ?? (source.chain === 'EVM' ? PricingType.Fixed : null),
-  }));
+const snapshotSourcePricingSchema = z.discriminatedUnion('pricingType', [
+  z.object({
+    pricingType: z.literal(PricingType.Fixed),
+    fixed: z.array(
+      z.object({
+        asset: z.string(),
+        amount: z
+          .string()
+          .regex(/^\d+$/, 'Amount must be a numeric string (BigInt format)'),
+        decimals: z.number().int().min(0).max(255).optional(),
+      })
+    ),
+  }),
+  z.object({
+    pricingType: z.literal(PricingType.Dynamic),
+    dynamic: z
+      .array(
+        z.object({
+          asset: z.string(),
+          decimals: z.number().int().min(0).max(255),
+        })
+      )
+      .max(1)
+      .optional(),
+  }),
+  z.object({ pricingType: z.literal(PricingType.Free) }),
+]);
+
+const snapshotSupportedPaymentSourceSchema = z.object({
+  chain: z.string(),
+  network: z.string(),
+  sourceIndex: z.number().int().min(0),
+  paymentSourceType: z.string().nullable(),
+  address: z.string(),
+  scheme: z.string().nullable(),
+  pricing: snapshotSourcePricingSchema,
+  payTo: z.string().nullable(),
+  resource: z.string().nullable(),
+  extra: z.unknown().optional(),
+});
 
 const snapshotEntrySchema = z.object({
   assetIdentifier: z.string().min(1),
@@ -83,13 +103,13 @@ const snapshotEntrySchema = z.object({
   paymentType: z.nativeEnum(PaymentType),
   metadataVersion: z.number().int().min(1),
   capability: snapshotCapabilitySchema.nullable(),
-  agentPricing: snapshotAgentPricingSchema,
+  agentPricing: snapshotAgentPricingSchema.nullable(),
   exampleOutputs: z.array(snapshotExampleOutputSchema),
 });
 
 const snapshotSchema = z
   .object({
-    version: z.literal('1.0.0'),
+    version: z.literal(SNAPSHOT_VERSION),
     exportedAt: z.string().datetime(),
     network: z.nativeEnum(Network),
     policyId: z.string().min(1),
@@ -124,7 +144,7 @@ const paymentSourcesEntrySchema = z.object({
 
 const paymentSourcesSchema = z
   .object({
-    version: z.literal('1.0.0'),
+    version: z.literal(SNAPSHOT_VERSION),
     exportedAt: z.string().datetime(),
     network: z.nativeEnum(Network),
     policyId: z.string().min(1),

--- a/src/utils/snapshot/types.ts
+++ b/src/utils/snapshot/types.ts
@@ -1,7 +1,9 @@
 import { Network, PaymentType, PricingType, Status } from '@prisma/client';
 
+export const SNAPSHOT_VERSION = '2.0.0' as const;
+
 interface SnapshotMetadata {
-  version: '1.0.0';
+  version: typeof SNAPSHOT_VERSION;
   exportedAt: string;
   network: Network;
   policyId: string;
@@ -58,7 +60,7 @@ export interface SnapshotEntry {
   paymentType: PaymentType;
   metadataVersion: number;
   capability: SnapshotCapability | null;
-  agentPricing: SnapshotAgentPricing;
+  agentPricing: SnapshotAgentPricing | null;
   exampleOutputs: SnapshotExampleOutput[];
 }
 
@@ -72,13 +74,20 @@ export interface Snapshot extends SnapshotMetadata {
 export interface SnapshotSupportedPaymentSource {
   chain: string;
   network: string;
+  sourceIndex: number;
   paymentSourceType: string | null;
   address: string;
   scheme: string | null;
-  pricingType: PricingType | null;
-  asset: string | null;
-  amount: string | null; // BigInt -> string
-  decimals: number | null;
+  pricing:
+    | {
+        pricingType: 'Fixed';
+        fixed: Array<{ asset: string; amount: string; decimals?: number }>;
+      }
+    | {
+        pricingType: 'Dynamic';
+        dynamic?: Array<{ asset: string; decimals: number }>;
+      }
+    | { pricingType: 'Free' };
   payTo: string | null;
   resource: string | null;
   extra?: unknown; // Prisma Json, passed through verbatim
@@ -94,7 +103,7 @@ export interface SnapshotEntryPaymentSources {
 // The companion payment-sources file. Only written when at least one entry in
 // the source carries payment sources.
 export interface PaymentSourcesSnapshot {
-  version: '1.0.0';
+  version: typeof SNAPSHOT_VERSION;
   exportedAt: string;
   network: Network;
   policyId: string;

--- a/src/utils/swagger-generator/openapi-docs.json
+++ b/src/utils/swagger-generator/openapi-docs.json
@@ -154,8 +154,150 @@
                                 "required": [
                                     "pricingType"
                                 ]
+                            },
+                            {
+                                "nullable": true
                             }
                         ]
+                    },
+                    "SupportedPaymentSources": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "chain": {
+                                    "type": "string"
+                                },
+                                "network": {
+                                    "type": "string"
+                                },
+                                "sourceIndex": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "paymentSourceType": {
+                                    "type": "string",
+                                    "nullable": true
+                                },
+                                "address": {
+                                    "type": "string"
+                                },
+                                "scheme": {
+                                    "type": "string",
+                                    "nullable": true
+                                },
+                                "pricing": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "pricingType": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Fixed"
+                                                    ]
+                                                },
+                                                "fixed": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "asset": {
+                                                                "type": "string"
+                                                            },
+                                                            "amount": {
+                                                                "type": "string"
+                                                            },
+                                                            "decimals": {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 255
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "asset",
+                                                            "amount"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "pricingType",
+                                                "fixed"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "pricingType": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Dynamic"
+                                                    ]
+                                                },
+                                                "dynamic": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "asset": {
+                                                                "type": "string"
+                                                            },
+                                                            "decimals": {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 255
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "asset",
+                                                            "decimals"
+                                                        ]
+                                                    },
+                                                    "maxItems": 1
+                                                }
+                                            },
+                                            "required": [
+                                                "pricingType"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "pricingType": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Free"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "pricingType"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "payTo": {
+                                    "type": "string",
+                                    "nullable": true
+                                },
+                                "resource": {
+                                    "type": "string",
+                                    "nullable": true
+                                }
+                            },
+                            "required": [
+                                "chain",
+                                "network",
+                                "sourceIndex",
+                                "paymentSourceType",
+                                "address",
+                                "scheme",
+                                "pricing",
+                                "payTo",
+                                "resource"
+                            ]
+                        }
                     },
                     "name": {
                         "type": "string"
@@ -270,6 +412,7 @@
                     "sellerWallet",
                     "Capability",
                     "AgentPricing",
+                    "SupportedPaymentSources",
                     "name",
                     "description",
                     "status",
@@ -504,6 +647,9 @@
                                 "required": [
                                     "pricingType"
                                 ]
+                            },
+                            {
+                                "nullable": true
                             }
                         ]
                     },
@@ -540,6 +686,10 @@
                                 "network": {
                                     "type": "string"
                                 },
+                                "sourceIndex": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
                                 "paymentSourceType": {
                                     "type": "string",
                                     "nullable": true
@@ -551,27 +701,96 @@
                                     "type": "string",
                                     "nullable": true
                                 },
-                                "pricingType": {
-                                    "type": "string",
-                                    "nullable": true,
-                                    "enum": [
-                                        "Fixed",
-                                        "Free",
-                                        "Dynamic",
-                                        null
+                                "pricing": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "pricingType": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Fixed"
+                                                    ]
+                                                },
+                                                "fixed": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "asset": {
+                                                                "type": "string"
+                                                            },
+                                                            "amount": {
+                                                                "type": "string"
+                                                            },
+                                                            "decimals": {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 255
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "asset",
+                                                            "amount"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "pricingType",
+                                                "fixed"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "pricingType": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Dynamic"
+                                                    ]
+                                                },
+                                                "dynamic": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "asset": {
+                                                                "type": "string"
+                                                            },
+                                                            "decimals": {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 255
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "asset",
+                                                            "decimals"
+                                                        ]
+                                                    },
+                                                    "maxItems": 1
+                                                }
+                                            },
+                                            "required": [
+                                                "pricingType"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "pricingType": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Free"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "pricingType"
+                                            ]
+                                        }
                                     ]
-                                },
-                                "asset": {
-                                    "type": "string",
-                                    "nullable": true
-                                },
-                                "amount": {
-                                    "type": "string",
-                                    "nullable": true
-                                },
-                                "decimals": {
-                                    "type": "integer",
-                                    "nullable": true
                                 },
                                 "payTo": {
                                     "type": "string",
@@ -585,13 +804,11 @@
                             "required": [
                                 "chain",
                                 "network",
+                                "sourceIndex",
                                 "paymentSourceType",
                                 "address",
                                 "scheme",
-                                "pricingType",
-                                "asset",
-                                "amount",
-                                "decimals",
+                                "pricing",
                                 "payTo",
                                 "resource"
                             ]


### PR DESCRIPTION
## Summary

- stores Fixed, Dynamic, and Free pricing under each ordered V2 payment source
- keeps top-level AgentPricing exclusively for V1 entries
- rejects wrong-version fields, malformed pricing, and duplicate options with row-level errors
- exposes source-owned pricing through registry and payment-information APIs
- updates snapshot import/export to the breaking 2.0.0 format

## Migration

- preserves RegistryEntry-owned V1 pricing
- moves existing V2 pricing under SupportedPaymentSource
- removes historical V1 source rows and marks incomplete V2 rows invalid
- resets affected registry cursors for a one-time authoritative on-chain resync, restoring exact source order and independent Cardano prices

## Validation

- TypeScript typecheck
- ESLint
- Prisma schema validation
- 16 focused registry metadata, serializer, and snapshot tests
- production build
- local E2E intentionally skipped; PR automation owns E2E

Companion payment-service PR: https://github.com/masumi-network/masumi-payment-service/pull/707