### PR TITLE
test(registry): strict V2 metadata accepts type + spec-url keys

### DIFF
--- a/src/services/cardano-registry/web3-cardano-v2-metadata.spec.ts
+++ b/src/services/cardano-registry/web3-cardano-v2-metadata.spec.ts
@@ -61,6 +61,31 @@ const sampleV2Metadata = {
 };
 
 describe('web3CardanoV2 metadata', () => {
+  it('accepts the type/openapi_spec_url/x402_resources_url keys (strict schema)', () => {
+    // The schema is .strict(); these keys must be allowed or every OpenApi/X402
+    // entry the indexer sees would be rejected as invalid.
+    expect(
+      web3CardanoV2MetadataSchema.safeParse({
+        ...sampleV2Metadata,
+        type: 'OpenAPI',
+        openapi_spec_url: 'https://agent.example/openapi.json',
+        x402_resources_url: 'https://agent.example/.well-known/x402.json',
+      }).success
+    ).toBe(true);
+  });
+
+  it('accepts a V2 entry with no api_base_url (OpenApi/X402 shape)', () => {
+    const withoutBaseUrl: Record<string, unknown> = { ...sampleV2Metadata };
+    delete withoutBaseUrl.api_base_url;
+    expect(
+      web3CardanoV2MetadataSchema.safeParse({
+        ...withoutBaseUrl,
+        type: 'OpenAPI',
+        openapi_spec_url: 'https://agent.example/openapi.json',
+      }).success
+    ).toBe(true);
+  });
+
   it('flattens grouped sources into Cardano + EVM rows', () => {
     const metadata = web3CardanoV2MetadataSchema.parse(sampleV2Metadata);
     const rows = buildV2SupportedPaymentSourceRows(metadata);


### PR DESCRIPTION
Follow-up to #195/#196 (merged): adds the test that landed just after those merged, so it wasn't included.

Guards the exact regression risk from the agent-type feature: the `.strict()` indexer metadata schema (`web3CardanoV2MetadataSchema`) must accept `type` / `openapi_spec_url` / `x402_resources_url` and a missing `api_base_url` — otherwise every OpenApi/X402 entry would be rejected on sync.

Test-only. 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)